### PR TITLE
python: refcounting for the handle's PyObjects.

### DIFF
--- a/librepo/python/handle-py.c
+++ b/librepo/python/handle-py.c
@@ -421,12 +421,14 @@ getinfo(_HandleObject *self, PyObject *args)
     case LRI_PROGRESSCB:
         if (self->progress_cb == NULL)
             Py_RETURN_NONE;
+        Py_INCREF(self->progress_cb);
         return self->progress_cb;
 
     /* callback data options */
     case LRI_PROGRESSDATA:
         if (self->progress_cb_data == NULL)
             Py_RETURN_NONE;
+        Py_INCREF(self->progress_cb_data);
         return self->progress_cb_data;
 
     default:

--- a/tests/python/tests/test_handle.py
+++ b/tests/python/tests/test_handle.py
@@ -1,9 +1,12 @@
 import unittest
 import librepo
 
+def foo_cb(data, total_to_download, downloaded):
+    pass
+
 class TestCaseHandle(unittest.TestCase):
     def test_handle_setopt_getinfo(self):
-        """No exception shoud be raised."""
+        """No exception should be raised."""
         h = librepo.Handle()
 
         self.assertFalse(h.getinfo(librepo.LRI_UPDATE))
@@ -37,8 +40,6 @@ class TestCaseHandle(unittest.TestCase):
         self.assertTrue(h.getinfo(librepo.LRI_LOCAL))
         h.setopt(librepo.LRO_LOCAL,  0)
         self.assertFalse(h.getinfo(librepo.LRI_LOCAL))
-
-        def foo_cb(data, total_to_download, downloaded): pass
 
         self.assertFalse(h.getinfo(librepo.LRI_PROGRESSCB))
         h.setopt(librepo.LRO_PROGRESSCB, foo_cb)
@@ -79,7 +80,7 @@ class TestCaseHandle(unittest.TestCase):
         self.assertEqual(h.getinfo(librepo.LRI_YUMBLIST), [])
 
     def test_handle_setget_attr(self):
-        """No exception shoud be raised."""
+        """No exception should be raised."""
         h = librepo.Handle()
 
         self.assertFalse(h.update)
@@ -113,8 +114,6 @@ class TestCaseHandle(unittest.TestCase):
         self.assertTrue(h.local)
         h.local =  0
         self.assertFalse(h.local)
-
-        def foo_cb(data, total_to_download, downloaded): pass
 
         self.assertFalse(h.progresscb)
         h.progresscb = foo_cb


### PR DESCRIPTION
Returned values from PyCFunctions need to have the refcount increased [1],
else segfaults (or worse) emerge.

The unit test doesn't look like it does much, but in fact it pretty
reliably reproduces a segfault.

[1] http://docs.python.org/2/c-api/structures.html?highlight=pycfunction#PyCFunction
