### PR TITLE
fix "make install" failure

### DIFF
--- a/librepo/python/python2/CMakeLists.txt
+++ b/librepo/python/python2/CMakeLists.txt
@@ -14,7 +14,6 @@ FILE(COPY ${librepo_COPIES} DESTINATION ./librepo/)
 
 ADD_LIBRARY(_librepomodule SHARED ${librepomodule_SRCS})
 SET_TARGET_PROPERTIES(_librepomodule PROPERTIES PREFIX "")
-SET_TARGET_PROPERTIES(_librepomodule PROPERTIES LIBRARY_OUTPUT_DIRECTORY "./librepo")
 TARGET_LINK_LIBRARIES(_librepomodule librepo)
 TARGET_LINK_LIBRARIES(_librepomodule
                         ${EXPAT_LIBRARIES}


### PR DESCRIPTION
before:

CMake Error at librepo/python/python2/cmake_install.cmake:62 (FILE):
  file INSTALL cannot find
  "/home/zpavlas/GIT/librepo/build/librepo/python/python2/librepo/_librepomodule.so".
Call Stack (most recent call first):
  librepo/python/cmake_install.cmake:37 (INCLUDE)
  librepo/cmake_install.cmake:107 (INCLUDE)
  cmake_install.cmake:37 (INCLUDE)

after:

-- Installing: /usr/lib/python2.7/site-packages/librepo/_librepomodule.so
-- Removed runtime path from "/usr/lib/python2.7/site-packages/librepo/_librepomodule.so"
