### PR TITLE
Support redefining %{gitrev} RPM macro from command line.

### DIFF
--- a/utils/make_rpm.sh
+++ b/utils/make_rpm.sh
@@ -45,9 +45,8 @@ if [ ! $? == "0" ]; then
     exit 1
 fi
 
-# Copy via sed
-sed -i "s/%global gitrev .*/%global gitrev $GITREV/g" "$PREFIX/$PACKAGE.spec"
-sed "s/%global gitrev .*/%global gitrev $GITREV/g" "$PREFIX/$PACKAGE.spec" > "$RPMBUILD_DIR/SPECS/$PACKAGE.spec"
+sed -i "s/%{\!?gitrev: %global gitrev .*/%{\!?gitrev: %global gitrev $GITREV}/g" "$PREFIX/$PACKAGE.spec"
+cp "$PREFIX/$PACKAGE.spec" "$RPMBUILD_DIR/SPECS/"
 if [ ! $? == "0" ]; then
     echo "Error while: cp $PREFIX/$PACKAGE.spec $RPMBUILD_DIR/SPECS/"
     exit 1


### PR DESCRIPTION
This together with the following change to the spec file:

```diff
diff --git a/librepo.spec b/librepo.spec
index d5582db..0884735 100644
--- a/librepo.spec
+++ b/librepo.spec
@@ -1,4 +1,4 @@
-%global gitrev d9bed0d
+%{!?gitrev: %global gitrev d9bed0d}
 # gitrev is output of: git rev-parse --short HEAD
 
 %if 0%{?rhel} != 0 && 0%{?rhel} <= 7
```

allows one to build librepo RPMs in Mock more easily than running `make_rpm.sh` in Mock (which requires copying files to and from the chroot and installing all the dependencies):

```bash
GITREV=`git rev-parse --short HEAD`
utils/make_tarball.sh "$GITREV"
mock --resultdir=. --define="gitrev $GITREV" --buildsrpm --spec librepo.spec --sources .
mock --resultdir=. --define="gitrev $GITREV" *.src.rpm
```

Also `make_rpm.sh` can get rid of the `sed` but I guess you still want to update the spec file with the new GITREV.

It will help us to build librepo nightly builds.

Let me know if there is any problem/ugliness.