### PR TITLE
tests: Skip the relevant tests if extended attributes are not supported

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -685,7 +685,13 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
 
         # Mark the file as it was downloaded by Librepo
         # Otherwise librepo refuse to resume
-        xattr.setxattr(pkg.local_path, "user.Librepo.DownloadInProgress", "")
+        try:
+            xattr.setxattr(pkg.local_path, "user.Librepo.DownloadInProgress",
+                           "")
+        except IOError as err:
+            if err.errno == 95:
+                self.skipTest('extended attributes are not supported')
+            raise
 
         # Now try to resume from bad URL
         pkgs = []


### PR DESCRIPTION
Issue #70

Please review this carefully. I don't know your coding conventions and I don't know whether you really want to skip the test. For me, it seems correct. I may also misunderstood the test.

Also note that `Unittest.skipTest` is supported on Python 2.7 and Python 3.1+ so if you support older Pythons, I need to find a different solution.

Otherwise, I'd appreciate if you could merge it as soon as possible.