### PR TITLE
Switch `command -v` for `which` in nosetest check

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_TEST(test_main run_tests.sh)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sys; sys.stdout.write('%s.%s' % (sys.version_info[0], sys.version_info[1]))" OUTPUT_VARIABLE PYTHON_MAJOR_DOT_MINOR_VERSION)
 set(NOSETEST_VERSION_SUFFIX "-${PYTHON_MAJOR_DOT_MINOR_VERSION}")
 
-execute_process(COMMAND command -v nosetests${NOSETEST_VERSION_SUFFIX}
+execute_process(COMMAND which nosetests${NOSETEST_VERSION_SUFFIX}
                 OUTPUT_QUIET ERROR_QUIET
                 RESULT_VARIABLE NOSE_CHECK_RESULT)
 IF (NOT NOSE_CHECK_RESULT STREQUAL "0")


### PR DESCRIPTION
Some distributions (such as Mageia) do not provide `/usr/bin/command`, and instead rely on it being an internal command in bash. However, that breaks the test in CMake for versioned nosetests binaries.

To correct this, I switched it to use `/usr/bin/which` to enable the same test for versioned nosetests binaries.