### PR TITLE
Use bytestring in xattr.setxattr() for python3-xattr

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -685,7 +685,7 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
 
         # Mark the file as it was downloaded by Librepo
         # Otherwise librepo refuse to resume
-        xattr.setxattr(pkg.local_path, "user.Librepo.DownloadInProgress", "")
+        xattr.setxattr(pkg.local_path, "user.Librepo.DownloadInProgress".encode(encoding='UTF-8'), "".encode(encoding='UTF-8'))
 
         # Now try to resume from bad URL
         pkgs = []


### PR DESCRIPTION
Apparently, python3-xattr (the newer xattr module for python) and python3-pyxattr (the older xattr module for python) aren't fully compatible. `xattr.setxattr()` will happily take strings in pyxattr, but xattr requires bytestrings. This changes it to use bytestrings.