### PR TITLE
New test: always try to download from the fastest mirror

### DIFF
--- a/tests/python/tests/servermock/yum_mock/config.py
+++ b/tests/python/tests/servermock/yum_mock/config.py
@@ -33,6 +33,7 @@ METALINK_FIRSTURLHASCORRUPTEDFILES = METALINK_DIR+"firsturlhascorruptedfiles.xml
 METALINK_VARSUB = METALINK_DIR+"varsub.xml"
 METALINK_VARSUB_LIST = [("version", "01")]
 METALINK_WITH_ALTERNATES = METALINK_DIR+"metalink_with_alternates.xml"
+METALINK_MIRRORS_01 = METALINK_DIR+"mirrors_01.xml"
 
 MIRRORLIST_DIR = "yum/static/mirrorlist/"
 MIRRORLIST_GOOD_01 = MIRRORLIST_DIR+"good_01"

--- a/tests/python/tests/servermock/yum_mock/static/metalink/mirrors_01.xml
+++ b/tests/python/tests/servermock/yum_mock/static/metalink/mirrors_01.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metalink version="3.0" xmlns="http://www.metalinker.org/" type="dynamic" pubdate="Tue, 11 Sep 2012 07:36:51 GMT" generator="mirrormanager" xmlns:mm0="http://127.0.0.1:5000/yum/static/metalink">
+  <files>
+    <file name="repomd.xml">
+      <resources maxconnections="1">
+        <url protocol="http" type="http" location="BG" preference="100" mm0:private="True">http://127.0.0.1:{PORT_PLACEHOLDER}/yum/static/01/repodata/repomd.xml</url>
+        <url protocol="http" type="http" location="CZ" preference="50"  mm0:private="True">http://127.0.0.1:{PORT_PLACEHOLDER}/yum/static/03/repodata/repomd.xml</url>
+        <url protocol="http" type="http" location="US" preference="10"  mm0:private="True">http://127.0.0.1:{PORT_PLACEHOLDER}/yum/static/04/repodata/repomd.xml</url>
+      </resources>
+    </file>
+  </files>
+</metalink>


### PR DESCRIPTION
When a package fails to download, librepo moves to the next mirror;
after a successfull download librepo should continue downloading
the remaining packages from the first mirror. In yum this was not
the case and every download failure was causing the usage of slower
mirrors even when the fastest ones had the remaining packages. This
test verifies this is not the case with librepo.


Note: I'm verifying the order in which packages failed to download from the mirrors because there's no way to verify that packages came from a particular mirror. If you change the order of the URLs in the metalink file the test will fail. 