### PR TITLE
Tolerate HTTP proxies with (conformant) heuristic caching

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -940,6 +940,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         if (ftruncate(fd, 0) == -1) {
             g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
                         "ftruncate() failed: %s", g_strerror(errno));
+            fclose(f);
+            curl_easy_cleanup(h);
             return FALSE;
         }
     }
@@ -970,17 +972,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         g_debug("%s: Used offset for download resume: %"G_GINT64_FORMAT,
                 __func__, used_offset);
 
-        c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
-                                (curl_off_t) used_offset);
-        if (c_rc != CURLE_OK) {
-            g_set_error(err, LR_DOWNLOADER_ERROR, LRE_CURL,
-                        "curl_easy_setopt(h, LR_DOWNLOADER_ERROR, %"
-                        G_GINT64_FORMAT") failed: %s",
-                        used_offset, curl_easy_strerror(c_rc));
-            fclose(f);
-            curl_easy_cleanup(h);
-            return FALSE;
-        }
+        curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
+                         (curl_off_t) used_offset);
     }
 
     // Add librepo extended attribute to the file
@@ -995,8 +988,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         assert(!target->target->resume);
         g_debug("%s: byterangestart is specified -> resume is set to %"
                 G_GINT64_FORMAT, __func__, target->target->byterangestart);
-        c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
-                                (curl_off_t) target->target->byterangestart);
+        curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
+                         (curl_off_t) target->target->byterangestart);
     }
 
     // Prepare progress callback

--- a/librepo/downloadtarget.c
+++ b/librepo/downloadtarget.c
@@ -106,6 +106,7 @@ lr_downloadtarget_new(LrHandle *handle,
     target->userdata        = userdata;
     target->byterangestart  = byterangestart;
     target->byterangeend    = byterangeend;
+    target->cacherevalidate = FALSE;
 
     return target;
 }

--- a/librepo/downloadtarget.h
+++ b/librepo/downloadtarget.h
@@ -130,6 +130,12 @@ typedef struct {
         User data - This data are not used by lr_downloader or touched
         by lr_downloadtarget_free. */
 
+    gboolean cacherevalidate; /*!<
+        Force HTTP proxy to revalidate cache:
+         0 - allow standard caching, generally fine as new versions of files
+             get new names
+         otherwise - force revalidate, needed for repomd.xml only */
+
 } LrDownloadTarget;
 
 /** Create new empty ::LrDownloadTarget.

--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -275,6 +275,10 @@ lr_yum_download_repomd(LrHandle *handle,
                                                      0,
                                                      0);
 
+    // Disable heuristic caching in HTTP proxies.
+    // Not needed for any other files, because they change names when updated.
+    target->cacherevalidate = TRUE;
+
     ret = lr_download_target(target, &tmp_err);
     assert((ret && !tmp_err) || (!ret && tmp_err));
 


### PR DESCRIPTION
> dnf failed sometimes when using a Polipo proxy.  repomd.xml was cached
> with out-of-data contents, causing download failure.  To avoid this,
> dnf should force revalidation ("Cache-Control: max-age=0") on repomd.xml.

> https://bugzilla.redhat.com/show_bug.cgi?id=1297762

I tested this on my own machine.  It seemed to send the desired Cache-Control header, and completed `dnf update`.  It was able to connect through my proxy mirror, as well as directly using the normal metalink.

I haven't tried to reproduce the failure condition.  I do want to keep using Polipo, and hopefully I'll use `dnf` enough to notice if it's still breaking.  It took at most 10 days to see a failure the first time.

DISCLAIMER I'm still slightly anxious.  I don't know how to assess the risk that this will break for some _other_ proxy!  Even though I can't imagine how it would break.