### PR TITLE
Caching proxy fix

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1028,7 +1028,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
     curl_easy_setopt(h, CURLOPT_HTTPHEADER, headers);
 
     // Add the new handle to the curl multi handle
-    curl_multi_add_handle(dd->multi_handle, h);
+    CURLMcode cm_rc = curl_multi_add_handle(dd->multi_handle, h);
+    assert(cm_rc == CURLM_OK);
 
     // Set the state of transfer as running
     target->state = LR_DS_RUNNING;

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -942,6 +942,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         if (ftruncate(fd, 0) == -1) {
             g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
                         "ftruncate() failed: %s", g_strerror(errno));
+            fclose(f);
+            curl_easy_cleanup(h);
             return FALSE;
         }
     }

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1014,9 +1014,9 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     // Set extra HTTP headers
     struct curl_slist *headers = NULL;
-    if (target->handle) {
+    if (target->handle && target->handle->httpheader) {
         // Fill in headers specified by user in LrHandle via LRO_HTTPHEADER
-        for (int x=0; target->handle->httpheader && target->handle->httpheader[x]; x++)
+        for (int x=0; target->handle->httpheader[x]; x++)
             headers = curl_slist_append(headers, target->handle->httpheader[x]);
     }
     if (target->target->no_cache) {

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -974,17 +974,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         g_debug("%s: Used offset for download resume: %"G_GINT64_FORMAT,
                 __func__, used_offset);
 
-        c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
-                                (curl_off_t) used_offset);
-        if (c_rc != CURLE_OK) {
-            g_set_error(err, LR_DOWNLOADER_ERROR, LRE_CURL,
-                        "curl_easy_setopt(h, LR_DOWNLOADER_ERROR, %"
-                        G_GINT64_FORMAT") failed: %s",
-                        used_offset, curl_easy_strerror(c_rc));
-            fclose(f);
-            curl_easy_cleanup(h);
-            return FALSE;
-        }
+        curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
+                         (curl_off_t) used_offset);
     }
 
     // Add librepo extended attribute to the file
@@ -999,8 +990,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         assert(!target->target->resume);
         g_debug("%s: byterangestart is specified -> resume is set to %"
                 G_GINT64_FORMAT, __func__, target->target->byterangestart);
-        c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
-                                (curl_off_t) target->target->byterangestart);
+        curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
+                         (curl_off_t) target->target->byterangestart);
     }
 
     // Prepare progress callback


### PR DESCRIPTION
> dnf failed sometimes when using a Polipo proxy.  repomd.xml was cached
> with out-of-data contents, causing download failure.  To avoid this,
> dnf should force revalidation ("Cache-Control: max-age=0") on repomd.xml.

> https://bugzilla.redhat.com/show_bug.cgi?id=1297762

I've seen the failure twice now.  Updating from a machine with the fixed librepo appeared to successfully flush the stale files from the caching proxy.

Thanks to @cgwalters for reviewing PR #77, my first attempt at this!

The skipped curl error checks I noticed in the modified function have been added in one final patch, because we weren't 100% sure about it.  Looks tolerable to me, though maybe only because I've been learning how to handle errors in Rust :).

downloader.c and elsewhere don't use `g_assert()`, so I've stuck with `assert()` for now.  Commit gives a justification for using `assert()`.  That doesn't quite apply to the `curl_multi_add_handle()` commit.  But I see `assert(!err || *err == NULL)` elsewhere, and I have to stop digging / yak shaving at some point...

<small>Further to my original comment, `||=` is not a thing in C :).  I agree it would be good to look at `__attribute__((cleanup))` for cleanup... and that this fix is not the right place for it.  (I only cared about code quality here, because I want _my_ new code to be both correct and consistent with surrounding code :-P).</small>