### PR TITLE
yum: Fix a memory leak in signature verification

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -875,6 +875,7 @@ lr_yum_download_remote(LrHandle *handle, LrResult *result, GError **err)
                                              path,
                                              handle->gnupghomedir,
                                              &tmp_err);
+                lr_free(signature);
                 if (!ret) {
                     g_debug("%s: GPG signature verification failed: %s",
                             __func__, tmp_err->message);
@@ -882,7 +883,6 @@ lr_yum_download_remote(LrHandle *handle, LrResult *result, GError **err)
                             "repomd.xml GPG signature verification error: ");
                     close(fd);
                     lr_free(path);
-                    lr_free(signature);
                     return FALSE;
                 }
                 g_debug("%s: GPG signature successfully verified", __func__);


### PR DESCRIPTION
This was caught by the libhif valgrind tests.