### PR TITLE
util: lr_prepend_url_protocol: don't resolve relative repo URLs using cwd

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -796,12 +796,9 @@ lr_handle_prepare_urls(LrHandle *handle, GError **err)
         _cleanup_free_ gchar *final_url = NULL;
 
         // Make sure that url has protocol specified
-        final_url = lr_prepend_url_protocol(url);
-        if (!final_url) {
-            g_set_error(err, LR_HANDLE_ERROR, LRE_BADURL,
-                        "Cannot resolve path for: \"%s\"", url);
+        final_url = lr_prepend_url_protocol(url, err);
+        if (!final_url)
             return FALSE;
-        }
 
         // Append the url into internal list of urls specified by LRO_URLS
         handle->urls_mirrors = lr_lrmirrorlist_append_url(
@@ -870,8 +867,8 @@ lr_handle_prepare_mirrorlist(LrHandle *handle, gchar *localpath, GError **err)
             return FALSE;
         }
 
-        url = lr_prepend_url_protocol(handle->mirrorlisturl);
-        if (!download_non_cached_url(handle, url, fd, err)) {
+        url = lr_prepend_url_protocol(handle->mirrorlisturl, err);
+        if (!url || !download_non_cached_url(handle, url, fd, err)) {
             close(fd);
             return FALSE;
         }
@@ -986,8 +983,8 @@ lr_handle_prepare_metalink(LrHandle *handle, gchar *localpath, GError **err)
             return FALSE;
         }
 
-        url = lr_prepend_url_protocol(handle->metalinkurl);
-        if (!download_non_cached_url(handle, url, fd, err)) {
+        url = lr_prepend_url_protocol(handle->metalinkurl, err);
+        if (!url || !download_non_cached_url(handle, url, fd, err)) {
             close(fd);
             return FALSE;
         }

--- a/librepo/util.c
+++ b/librepo/util.c
@@ -37,6 +37,7 @@
 #include "version.h"
 #include "metalink.h"
 #include "cleanup.h"
+#include "rcodes.h"
 
 #define DIR_SEPARATOR   "/"
 #define ENV_DEBUG       "LIBREPO_DEBUG"
@@ -315,10 +316,9 @@ lr_copy_content(int source, int dest)
 }
 
 char *
-lr_prepend_url_protocol(const char *path)
+lr_prepend_url_protocol(const char *path, GError **err)
 {
-    if (!path)
-        return NULL;
+    assert(path);
 
     if (strstr(path, "://"))  // Protocol was specified
         return g_strdup(path);
@@ -329,14 +329,10 @@ lr_prepend_url_protocol(const char *path)
     if (path[0] == '/')  // Path is absolute path
         return g_strconcat("file://", path, NULL);
 
-    char *path_with_protocol, *resolved_path = realpath(path, NULL);
-    if (!resolved_path) {
-        g_debug("%s: %s - realpath: %s ", __func__, path, g_strerror(errno));
-        return NULL;
-    }
-    path_with_protocol = g_strconcat("file://", resolved_path, NULL);
-    free(resolved_path);
-    return path_with_protocol;
+    // Path is relative, but we didn't have any base url
+    g_set_error(err, LR_HANDLE_ERROR, LRE_BADURL,
+                "Invalid URL: \"%s\"", path);
+    return NULL;
 }
 
 gchar *

--- a/librepo/util.h
+++ b/librepo/util.h
@@ -111,24 +111,25 @@ char *lr_pathconcat(const char *str, ...) G_GNUC_NULL_TERMINATED;
 
 /** Recursively remove directory.
  * @param path          Path to the directory.
- * @return              0 on succes, -1 on error.
+ * @return              0 on success, -1 on error.
  */
 int lr_remove_dir(const char *path);
 
 /** Copy content from source file descriptor to the dest file descriptor.
  * @param source        Source opened file descriptor
  * @param dest          Destination openede file descriptor
- * @return              0 on succes, -1 on error
+ * @return              0 on success, -1 on error
  */
 int lr_copy_content(int source, int dest);
 
 /** If protocol is specified ("http://foo") return copy of path.
  * If path is absolute ("/foo/bar/") return path with "file://" prefix.
- * If path is relative ("bar/") return absolute path with "file://" prefix.
- * @param               path
- * @return              url with protocol
+ * If path is relative ("bar/"), the result is an error
+ * @param path
+ * @param error         GError **
+ * @return              url with protocol, NULL on error
  */
-char *lr_prepend_url_protocol(const char *path);
+char *lr_prepend_url_protocol(const char *path, GError **err);
 
 /** Same as g_string_chunk_insert, but allows NULL as string.
  * If the string is NULL, then returns NULL and do nothing.

--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -404,15 +404,16 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
     def test_download_packages_with_baseurl(self):
         h = librepo.Handle()
 
-        url = "%s%s" % (self.MOCKURL, config.REPO_YUM_01_PATH)
-        h.urls = ["."]
+        url = "%s%s" % (self.MOCKURL, config.BADURL)
+        baseurl = "%s%s" % (self.MOCKURL, config.REPO_YUM_01_PATH)
+        h.urls = [url]
         h.repotype = librepo.LR_YUMREPO
 
         pkgs = []
         pkgs.append(librepo.PackageTarget(config.PACKAGE_01_01,
                                           handle=h,
                                           dest=self.tmpdir,
-                                          base_url=url))
+                                          base_url=baseurl))
 
         librepo.download_packages(pkgs)
 

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -236,22 +236,28 @@ END_TEST
 START_TEST(test_prepend_url_protocol)
 {
     gchar *url = NULL;
+    GError *err = NULL;
 
-    url = lr_prepend_url_protocol("/tmp");
+    url = lr_prepend_url_protocol("/tmp", NULL);
     fail_if(g_strcmp0(url, "file:///tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("file:///tmp");
+    url = lr_prepend_url_protocol("file:///tmp", NULL);
     fail_if(g_strcmp0(url, "file:///tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("http://tmp");
+    url = lr_prepend_url_protocol("http://tmp", NULL);
     fail_if(g_strcmp0(url, "http://tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("file:/tmp");
+    url = lr_prepend_url_protocol("file:/tmp", NULL);
     fail_if(g_strcmp0(url, "file:/tmp"));
     g_free(url);
+
+    url = lr_prepend_url_protocol("relative/path", &err);
+    fail_if(url != NULL);
+    fail_if(err == NULL);
+    g_error_free(err);
 }
 END_TEST
 


### PR DESCRIPTION
It won't go well when those repo URLs come from config files.

Users specifying repo URLs as run-time options shouldn't expect special
treatment.  They can easily use `$(pwd)`

`test_download_packages_with_baseurl` relied on using "." as a non-existent
repo, for some reason.  Fix it to use config.BADURL.  Copied+pasted from
`test_download_package_with_baseurl`.
