### PR TITLE
Improve error handling, cleanup

### DIFF
--- a/librepo/cleanup.h
+++ b/librepo/cleanup.h
@@ -31,7 +31,7 @@
 
 G_BEGIN_DECLS
 
-static void
+static inline void
 lr_close(int fildes)
 {
     if (fildes < 0)
@@ -40,23 +40,23 @@ lr_close(int fildes)
 }
 
 #define LR_DEFINE_CLEANUP_FUNCTION(Type, name, func) \
-  static inline void name (void *v) \
+  static inline void name (Type *v) \
   { \
-    func (*(Type*)v); \
+    func (*v); \
   }
 
 #define LR_DEFINE_CLEANUP_FUNCTION0(Type, name, func) \
-  static inline void name (void *v) \
+  static inline void name (Type *v) \
   { \
-    if (*(Type*)v) \
-      func (*(Type*)v); \
+    if (*v) \
+      func (*v); \
   }
 
 #define LR_DEFINE_CLEANUP_FUNCTIONt(Type, name, func) \
-  static inline void name (void *v) \
+  static inline void name (Type *v) \
   { \
-    if (*(Type*)v) \
-      func (*(Type*)v, TRUE); \
+    if (*v) \
+      func (*v, TRUE); \
   }
 
 LR_DEFINE_CLEANUP_FUNCTION0(GArray*, lr_local_array_unref, g_array_unref)
@@ -76,8 +76,17 @@ LR_DEFINE_CLEANUP_FUNCTIONt(GString*, lr_local_free_string, g_string_free)
 
 LR_DEFINE_CLEANUP_FUNCTION(char**, lr_local_strfreev, g_strfreev)
 LR_DEFINE_CLEANUP_FUNCTION(GList*, lr_local_free_list, g_list_free)
-LR_DEFINE_CLEANUP_FUNCTION(void*, lr_local_free, g_free)
 LR_DEFINE_CLEANUP_FUNCTION(int, lr_local_file_close, lr_close)
+
+/*
+ * g_free() could be used for any pointer type.
+ * To avoid warnings, we must take void * in place of void **.
+ */
+static inline void
+lr_local_free(void *v)
+{
+    g_free(*(void **)v);
+}
 
 #define _cleanup_dir_close_ __attribute__ ((cleanup(lr_local_dir_close)))
 #define _cleanup_file_close_ __attribute__ ((cleanup(lr_local_file_close)))

--- a/librepo/cleanup.h
+++ b/librepo/cleanup.h
@@ -76,6 +76,7 @@ LR_DEFINE_CLEANUP_FUNCTIONt(GString*, lr_local_free_string, g_string_free)
 
 LR_DEFINE_CLEANUP_FUNCTION(char**, lr_local_strfreev, g_strfreev)
 LR_DEFINE_CLEANUP_FUNCTION(GList*, lr_local_free_list, g_list_free)
+LR_DEFINE_CLEANUP_FUNCTION(GSList*, lr_local_free_slist, g_slist_free)
 LR_DEFINE_CLEANUP_FUNCTION(int, lr_local_fd_close, lr_close)
 
 /*
@@ -95,6 +96,7 @@ lr_local_free(void *v)
 #define _cleanup_checksum_free_ __attribute__ ((cleanup(lr_local_checksum_free)))
 #define _cleanup_error_free_ __attribute__ ((cleanup(lr_local_free_error)))
 #define _cleanup_list_free_ __attribute__ ((cleanup(lr_local_free_list)))
+#define _cleanup_slist_free_ __attribute__ ((cleanup(lr_local_free_slist)))
 #define _cleanup_string_free_ __attribute__ ((cleanup(lr_local_free_string)))
 #define _cleanup_strv_free_ __attribute__ ((cleanup(lr_local_strfreev)))
 #define _cleanup_array_unref_ __attribute__ ((cleanup(lr_local_array_unref)))

--- a/librepo/cleanup.h
+++ b/librepo/cleanup.h
@@ -76,7 +76,7 @@ LR_DEFINE_CLEANUP_FUNCTIONt(GString*, lr_local_free_string, g_string_free)
 
 LR_DEFINE_CLEANUP_FUNCTION(char**, lr_local_strfreev, g_strfreev)
 LR_DEFINE_CLEANUP_FUNCTION(GList*, lr_local_free_list, g_list_free)
-LR_DEFINE_CLEANUP_FUNCTION(int, lr_local_file_close, lr_close)
+LR_DEFINE_CLEANUP_FUNCTION(int, lr_local_fd_close, lr_close)
 
 /*
  * g_free() could be used for any pointer type.
@@ -89,7 +89,7 @@ lr_local_free(void *v)
 }
 
 #define _cleanup_dir_close_ __attribute__ ((cleanup(lr_local_dir_close)))
-#define _cleanup_file_close_ __attribute__ ((cleanup(lr_local_file_close)))
+#define _cleanup_fd_close_ __attribute__ ((cleanup(lr_local_fd_close)))
 #define _cleanup_timer_destroy_ __attribute__ ((cleanup(lr_local_destroy_timer)))
 #define _cleanup_free_ __attribute__ ((cleanup(lr_local_free)))
 #define _cleanup_checksum_free_ __attribute__ ((cleanup(lr_local_checksum_free)))

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -2102,7 +2102,7 @@ check_transfer_statuses(LrDownload *dd, GError **err)
 
     while ((msg = curl_multi_info_read(dd->multi_handle, &msgs_in_queue))) {
         LrTarget *target = NULL;
-        char *effective_url = NULL;
+        _cleanup_free_ char *effective_url = NULL;
         int fd;
         gboolean matches = TRUE;
         GError *transfer_err = NULL;
@@ -2395,8 +2395,6 @@ transfer_error:
             lr_downloadtarget_set_effectiveurl(target->target,
                                                effective_url);
         }
-
-        lr_free(effective_url);
 
         if (fail_fast_error) {
             // Interrupt whole downloading

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1423,8 +1423,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
     c_rc = curl_easy_setopt(h, CURLOPT_ERRORBUFFER, target->errorbuffer);
     if (c_rc != CURLE_OK) {
         g_set_error(err, LR_DOWNLOADER_ERROR, LRE_CURL,
-                    "curl_easy_setopt(h, CURLOPT_ERRORBUFFER, %s) failed: %s",
-                    full_url, curl_easy_strerror(c_rc));
+                    "curl_easy_setopt(h, CURLOPT_ERRORBUFFER, target->errorbuffer) failed: %s",
+                    curl_easy_strerror(c_rc));
         goto fail;
     }
 

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1883,6 +1883,7 @@ check_finished_transfer_checksum(int fd,
                                  GError **transfer_err,
                                  GError **err)
 {
+    gboolean ret = TRUE;
     gboolean matches = TRUE;
     GSList *calculated_chksums = NULL;
 
@@ -1895,15 +1896,15 @@ check_finished_transfer_checksum(int fd,
             continue;  // Bad checksum
 
         lseek(fd, 0, SEEK_SET);
-        gboolean ret = lr_checksum_fd_compare(chksum->type,
-                                              fd,
-                                              chksum->value,
-                                              1,
-                                              &matches,
-                                              &calculated,
-                                              err);
+        ret = lr_checksum_fd_compare(chksum->type,
+                                     fd,
+                                     chksum->value,
+                                     1,
+                                     &matches,
+                                     &calculated,
+                                     err);
         if (!ret)
-            return FALSE;
+            goto cleanup;
 
         // Store calculated checksum
         calculated_chksum = lr_downloadtargetchecksum_new(chksum->type,
@@ -1939,10 +1940,11 @@ check_finished_transfer_checksum(int fd,
                 "Calculated: %s Expected: %s", calculated, expected);
     }
 
+cleanup:
     g_slist_free_full(calculated_chksums,
                       (GDestroyNotify) lr_downloadtargetchecksum_free);
 
-    return TRUE;
+    return ret;
 }
 
 

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1877,11 +1877,11 @@ list_of_checksums_to_str(GSList *checksums)
 
 
 static gboolean
-check_finished_trasfer_checksum(int fd,
-                                GSList *checksums,
-                                gboolean *checksum_matches,
-                                GError **transfer_err,
-                                GError **err)
+check_finished_transfer_checksum(int fd,
+                                 GSList *checksums,
+                                 gboolean *checksum_matches,
+                                 GError **transfer_err,
+                                 GError **err)
 {
     gboolean matches = TRUE;
     GSList *calculated_chksums = NULL;
@@ -2188,7 +2188,7 @@ check_transfer_statuses(LrDownload *dd, GError **err)
             }
         } else {
         #endif /* WITH_ZCHUNK */
-            ret = check_finished_trasfer_checksum(fd,
+            ret = check_finished_transfer_checksum(fd,
                                                   target->target->checksums,
                                                   &matches,
                                                   &transfer_err,

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1554,17 +1554,20 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
         // Fill in headers specified by user in LrHandle via LRO_HTTPHEADER
         for (int x=0; target->handle->httpheader[x]; x++) {
             headers = curl_slist_append(headers, target->handle->httpheader[x]);
-            assert(headers);
+            if (!headers)
+                lr_out_of_memory();
         }
     }
     if (target->target->no_cache) {
         // Add headers that tell proxy to serve us fresh data
         headers = curl_slist_append(headers, "Cache-Control: no-cache");
         headers = curl_slist_append(headers, "Pragma: no-cache");
-        assert(headers);
+        if (!headers)
+            lr_out_of_memory();
     }
     target->curl_rqheaders = headers;
-    curl_easy_setopt(h, CURLOPT_HTTPHEADER, headers);
+    c_rc = curl_easy_setopt(h, CURLOPT_HTTPHEADER, headers);
+    assert(c_rc == CURLE_OK);
 
     // Add the new handle to the curl multi handle
     CURLMcode cm_rc = curl_multi_add_handle(dd->multi_handle, h);

--- a/librepo/fastestmirror.c
+++ b/librepo/fastestmirror.c
@@ -466,6 +466,7 @@ lr_fastestmirror_perform(GSList *list,
             g_set_error(err, LR_FASTESTMIRROR_ERROR, LRE_CURLM,
                         "curl_multi_fdset() error: %s",
                         curl_multi_strerror(cm_rc));
+            curl_multi_cleanup(multihandle);
             return FALSE;
         }
 
@@ -476,6 +477,7 @@ lr_fastestmirror_perform(GSList *list,
             } else {
                 g_set_error(err, LR_FASTESTMIRROR_ERROR, LRE_SELECT,
                             "select() error: %s", g_strerror(errno));
+                curl_multi_cleanup(multihandle);
                 return FALSE;
             }
         }

--- a/librepo/fastestmirror.c
+++ b/librepo/fastestmirror.c
@@ -27,6 +27,7 @@
 #include <curl/curl.h>
 
 #include "util.h"
+#include "cleanup.h"
 #include "handle_internal.h"
 #include "rcodes.h"
 #include "fastestmirror.h"
@@ -248,7 +249,8 @@ lr_fastestmirrorcache_write(LrFastestMirrorCache *cache, GError **err)
 
     // Gen cache content
     GError *tmp_err = NULL;
-    gchar *content = g_key_file_to_data(cache->keyfile, NULL, &tmp_err);
+    _cleanup_free_ gchar *content =
+                          g_key_file_to_data(cache->keyfile, NULL, &tmp_err);
     if (tmp_err) {
         g_propagate_error(err, tmp_err);
         return FALSE;
@@ -264,7 +266,6 @@ lr_fastestmirrorcache_write(LrFastestMirrorCache *cache, GError **err)
 
     fputs(content, f);
     fclose(f);
-    g_free(content);
 
     return TRUE;
 }

--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -796,7 +796,9 @@ lr_handle_prepare_mirrorlist(LrHandle *handle, gchar *localpath, GError **err)
         return TRUE;
     } else if (localpath && !handle->mirrorlisturl) {
         // Just try to use mirrorlist of the local repository
-        gchar *path = lr_pathconcat(localpath, "mirrorlist", NULL);
+        _cleanup_free_ gchar *path;
+        path = lr_pathconcat(localpath, "mirrorlist", NULL);
+
         if (g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
             g_debug("%s: Local mirrorlist found at %s", __func__, path);
             fd = open(path, O_RDONLY);
@@ -804,13 +806,10 @@ lr_handle_prepare_mirrorlist(LrHandle *handle, gchar *localpath, GError **err)
                 g_set_error(err, LR_HANDLE_ERROR, LRE_IO,
                             "Cannot open %s: %s",
                             path, g_strerror(errno));
-                g_free(path);
                 return FALSE;
             }
-            g_free(path);
         } else {
             // No local mirrorlist
-            g_free(path);
             return TRUE;
         }
     } else if (!handle->mirrorlisturl) {
@@ -912,7 +911,9 @@ lr_handle_prepare_metalink(LrHandle *handle, gchar *localpath, GError **err)
         return TRUE;
     } else if (localpath && !handle->metalinkurl) {
         // Just try to use metalink of the local repository
-        gchar *path = lr_pathconcat(localpath, "metalink.xml", NULL);
+        _cleanup_free_ gchar *path;
+        path = lr_pathconcat(localpath, "metalink.xml", NULL);
+
         if (g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
             g_debug("%s: Local metalink.xml found at %s", __func__, path);
             fd = open(path, O_RDONLY);
@@ -920,13 +921,10 @@ lr_handle_prepare_metalink(LrHandle *handle, gchar *localpath, GError **err)
                 g_set_error(err, LR_HANDLE_ERROR, LRE_IO,
                             "Cannot open %s: %s",
                             path, g_strerror(errno));
-                g_free(path);
                 return FALSE;
             }
-            g_free(path);
         } else {
             // No local metalink
-            g_free(path);
             return TRUE;
         }
     } else if (!handle->metalinkurl) {

--- a/librepo/package_downloader.c
+++ b/librepo/package_downloader.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 
 #include "types.h"
+#include "cleanup.h"
 #include "util.h"
 #include "package_downloader.h"
 #include "handle_internal.h"
@@ -534,7 +535,7 @@ lr_check_packages(GSList *targets,
     }
 
     for (GSList *elem = targets; elem; elem = g_slist_next(elem)) {
-        gchar *local_path;
+        _cleanup_free_ gchar *local_path = NULL;
         LrPackageTarget *packagetarget = elem->data;
 
         // Prepare destination filename

--- a/librepo/package_downloader.c
+++ b/librepo/package_downloader.c
@@ -242,7 +242,7 @@ lr_download_packages(GSList *targets,
 
     // Prepare targets
     for (GSList *elem = targets; elem; elem = g_slist_next(elem)) {
-        gchar *local_path;
+        _cleanup_free_ gchar *local_path = NULL;
         LrPackageTarget *packagetarget = elem->data;
         LrDownloadTarget *downloadtarget;
         gint64 realsize = -1;
@@ -255,11 +255,12 @@ lr_download_packages(GSList *targets,
         if (packagetarget->dest) {
             if (g_file_test(packagetarget->dest, G_FILE_TEST_IS_DIR)) {
                 // Dir specified
-                gchar *file_basename = g_path_get_basename(packagetarget->relative_url);
+                _cleanup_free_ gchar *file_basename;
+                file_basename = g_path_get_basename(packagetarget->relative_url);
+
                 local_path = g_build_filename(packagetarget->dest,
                                               file_basename,
                                               NULL);
-                g_free(file_basename);
             } else {
                 local_path = g_strdup(packagetarget->dest);
             }
@@ -270,7 +271,6 @@ lr_download_packages(GSList *targets,
 
         packagetarget->local_path = g_string_chunk_insert(packagetarget->chunk,
                                                           local_path);
-        g_free(local_path);
 
         // Check expected size and real size if the file exists
         if (doresume
@@ -542,11 +542,12 @@ lr_check_packages(GSList *targets,
         if (packagetarget->dest) {
             if (g_file_test(packagetarget->dest, G_FILE_TEST_IS_DIR)) {
                 // Dir specified
-                gchar *file_basename = g_path_get_basename(packagetarget->relative_url);
+                _cleanup_free_ gchar *file_basename;
+                file_basename = g_path_get_basename(packagetarget->relative_url);
+
                 local_path = g_build_filename(packagetarget->dest,
                                               file_basename,
                                               NULL);
-                g_free(file_basename);
             } else {
                 local_path = g_strdup(packagetarget->dest);
             }

--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -1103,7 +1103,7 @@ lr_yum_use_local_load_base(LrHandle *handle,
     GError *tmp_err = NULL;
     _cleanup_free_ gchar *path = NULL;
     _cleanup_free_ gchar *sig = NULL;
-    _cleanup_file_close_ int fd = -1;
+    _cleanup_fd_close_ int fd = -1;
 
     if (handle->mirrorlist_fd != -1) {
         // Locate mirrorlist if available.

--- a/tests/test_repoconf.c
+++ b/tests/test_repoconf.c
@@ -509,7 +509,7 @@ END_TEST
 
 START_TEST(test_write_repoconf)
 {
-    _cleanup_file_close_ int rc = -1;
+    _cleanup_fd_close_ int rc = -1;
     gboolean ret;
     LrYumRepoConfs *confs;
     LrYumRepoConf * conf;


### PR DESCRIPTION
@cgwalters suggested the cleanup attribute could be used to make sure we
don't leak resources when prepare_next_transfer() fails, as this was overlooked in
the past.
#77 (comment)

It took a while to untangle to my satisfaction, but I think it helps.  It turns out we'd still overlooked closing the one fd in there :).

At the same I noticed a "few" other error paths which could be improved.  Enjoy!
