### PR TITLE
Don't resolve relative repo URLs using cwd

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -796,12 +796,9 @@ lr_handle_prepare_urls(LrHandle *handle, GError **err)
         _cleanup_free_ gchar *final_url = NULL;
 
         // Make sure that url has protocol specified
-        final_url = lr_prepend_url_protocol(url);
-        if (!final_url) {
-            g_set_error(err, LR_HANDLE_ERROR, LRE_BADURL,
-                        "Cannot resolve path for: \"%s\"", url);
+        final_url = lr_add_url_protocol(url, err);
+        if (!final_url)
             return FALSE;
-        }
 
         // Append the url into internal list of urls specified by LRO_URLS
         handle->urls_mirrors = lr_lrmirrorlist_append_url(
@@ -870,8 +867,8 @@ lr_handle_prepare_mirrorlist(LrHandle *handle, gchar *localpath, GError **err)
             return FALSE;
         }
 
-        url = lr_prepend_url_protocol(handle->mirrorlisturl);
-        if (!download_non_cached_url(handle, url, fd, err)) {
+        url = lr_add_url_protocol(handle->mirrorlisturl, err);
+        if (!url || !download_non_cached_url(handle, url, fd, err)) {
             close(fd);
             return FALSE;
         }
@@ -986,8 +983,8 @@ lr_handle_prepare_metalink(LrHandle *handle, gchar *localpath, GError **err)
             return FALSE;
         }
 
-        url = lr_prepend_url_protocol(handle->metalinkurl);
-        if (!download_non_cached_url(handle, url, fd, err)) {
+        url = lr_add_url_protocol(handle->metalinkurl, err);
+        if (!url || !download_non_cached_url(handle, url, fd, err)) {
             close(fd);
             return FALSE;
         }

--- a/librepo/rcodes.c
+++ b/librepo/rcodes.c
@@ -194,3 +194,9 @@ lr_yum_error_quark(void)
 {
     return g_quark_from_static_string("lr_yum_error");
 }
+
+GQuark
+lr_util_error_quark(void)
+{
+    return g_quark_from_static_string("lr_util_error");
+}

--- a/librepo/rcodes.h
+++ b/librepo/rcodes.h
@@ -146,6 +146,7 @@ const char *lr_strerror(int rc);
 #define LR_REPOMD_ERROR             lr_repomd_error_quark()
 #define LR_REPOUTIL_YUM_ERROR       lr_repoutil_yum_error_quark()
 #define LR_RESULT_ERROR             lr_result_error_quark()
+#define LR_UTIL_ERROR             lr_util_error_quark()
 #define LR_XML_PARSER_ERROR         lr_xml_parser_error_quark()
 #define LR_YUM_ERROR                lr_yum_error_quark()
 
@@ -161,6 +162,7 @@ GQuark lr_repoconf_error_quark(void);
 GQuark lr_repomd_error_quark(void);
 GQuark lr_repoutil_yum_error_quark(void);
 GQuark lr_result_error_quark(void);
+GQuark lr_util_error_quark(void);
 GQuark lr_xml_parser_error_quark(void);
 GQuark lr_yum_error_quark(void);
 

--- a/librepo/util.h
+++ b/librepo/util.h
@@ -111,24 +111,35 @@ char *lr_pathconcat(const char *str, ...) G_GNUC_NULL_TERMINATED;
 
 /** Recursively remove directory.
  * @param path          Path to the directory.
- * @return              0 on succes, -1 on error.
+ * @return              0 on success, -1 on error.
  */
 int lr_remove_dir(const char *path);
 
 /** Copy content from source file descriptor to the dest file descriptor.
  * @param source        Source opened file descriptor
  * @param dest          Destination openede file descriptor
- * @return              0 on succes, -1 on error
+ * @return              0 on success, -1 on error
  */
 int lr_copy_content(int source, int dest);
 
 /** If protocol is specified ("http://foo") return copy of path.
  * If path is absolute ("/foo/bar/") return path with "file://" prefix.
- * If path is relative ("bar/") return absolute path with "file://" prefix.
- * @param               path
- * @return              url with protocol
+ * If path is relative ("bar/"), the result is an error
+ * @param path
+ * @param error         GError **
+ * @return              url with protocol, NULL on error
  */
-char *lr_prepend_url_protocol(const char *path);
+char *lr_add_url_protocol(const char *path, GError **err);
+
+/** Deprecated version of lr_add_url_protocol.
+ * Relative paths are resolved using realpath.  This uses the program's
+ * working directory, which doesn't make sense for urls in config files.
+ * It returns NULL if there is an error in the path, e.g. it does not exist
+ * (this was not previously documented).
+ * @param path
+ * @return              url with protocol, NULL on error
+ */
+__attribute__ ((deprecated)) char *lr_prepend_url_protocol(const char *path);
 
 /** Same as g_string_chunk_insert, but allows NULL as string.
  * If the string is NULL, then returns NULL and do nothing.
@@ -187,7 +198,7 @@ lr_strv_dup(gchar **array);
 gboolean
 lr_is_local_path(const gchar *path);
 
-/** Re-implementatio of g_key_file_save_to_file,
+/** Re-implementation of g_key_file_save_to_file,
  * because the function is available since 2.40 but we need
  * to support older glib
  * @param key_file  key file

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ SET (librepotest_SRCS
      testsys.c
      test_url_substitution.c
      test_util.c
+     test_util_deprecated.c
      test_version.c
     )
 

--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -404,15 +404,16 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
     def test_download_packages_with_baseurl(self):
         h = librepo.Handle()
 
-        url = "%s%s" % (self.MOCKURL, config.REPO_YUM_01_PATH)
-        h.urls = ["."]
+        url = "%s%s" % (self.MOCKURL, config.BADURL)
+        baseurl = "%s%s" % (self.MOCKURL, config.REPO_YUM_01_PATH)
+        h.urls = [url]
         h.repotype = librepo.LR_YUMREPO
 
         pkgs = []
         pkgs.append(librepo.PackageTarget(config.PACKAGE_01_01,
                                           handle=h,
                                           dest=self.tmpdir,
-                                          base_url=url))
+                                          base_url=baseurl))
 
         librepo.download_packages(pkgs)
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -22,6 +22,7 @@
 #include "test_repomd.h"
 #include "test_url_substitution.h"
 #include "test_util.h"
+#include "test_util_deprecated.h"
 #include "test_version.h"
 #include "testsys.h"
 
@@ -117,6 +118,7 @@ main(int argc, char **argv)
     srunner_add_suite(sr, repomd_suite());
     srunner_add_suite(sr, url_substitution_suite());
     srunner_add_suite(sr, util_suite());
+    srunner_add_suite(sr, util_deprecated_suite());
     srunner_add_suite(sr, version_suite());
     srunner_run_all(sr, CK_NORMAL);
     number_failed = srunner_ntests_failed(sr);

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -233,25 +233,31 @@ START_TEST(test_is_local_path)
 }
 END_TEST
 
-START_TEST(test_prepend_url_protocol)
+START_TEST(test_add_url_protocol)
 {
     gchar *url = NULL;
+    GError *err = NULL;
 
-    url = lr_prepend_url_protocol("/tmp");
+    url = lr_add_url_protocol("/tmp", NULL);
     fail_if(g_strcmp0(url, "file:///tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("file:///tmp");
+    url = lr_add_url_protocol("file:///tmp", NULL);
     fail_if(g_strcmp0(url, "file:///tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("http://tmp");
+    url = lr_add_url_protocol("http://tmp", NULL);
     fail_if(g_strcmp0(url, "http://tmp"));
     g_free(url);
 
-    url = lr_prepend_url_protocol("file:/tmp");
+    url = lr_add_url_protocol("file:/tmp", NULL);
     fail_if(g_strcmp0(url, "file:/tmp"));
     g_free(url);
+
+    url = lr_add_url_protocol("relative/path", &err);
+    fail_if(url != NULL);
+    fail_if(err == NULL);
+    g_error_free(err);
 }
 END_TEST
 
@@ -271,7 +277,7 @@ util_suite(void)
     tcase_add_test(tc, test_url_without_path);
     tcase_add_test(tc, test_strv_dup);
     tcase_add_test(tc, test_is_local_path);
-    tcase_add_test(tc, test_prepend_url_protocol);
+    tcase_add_test(tc, test_add_url_protocol);
     suite_add_tcase(s, tc);
     return s;
 }

--- a/tests/test_util_deprecated.c
+++ b/tests/test_util_deprecated.c
@@ -1,0 +1,47 @@
+#define _GNU_SOURCE
+#include "librepo/util.h"
+
+#include "fixtures.h"
+#include "testsys.h"
+#include "test_util.h"
+
+
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+START_TEST(test_prepend_url_protocol)
+{
+    gchar *url = NULL;
+
+    url = lr_prepend_url_protocol("/tmp");
+    fail_if(g_strcmp0(url, "file:///tmp"));
+    g_free(url);
+
+    url = lr_prepend_url_protocol("file:///tmp");
+    fail_if(g_strcmp0(url, "file:///tmp"));
+    g_free(url);
+
+    url = lr_prepend_url_protocol("http://tmp");
+    fail_if(g_strcmp0(url, "http://tmp"));
+    g_free(url);
+
+    url = lr_prepend_url_protocol("file:/tmp");
+    fail_if(g_strcmp0(url, "file:/tmp"));
+    g_free(url);
+
+    url = lr_prepend_url_protocol("..");
+    fail_if(!g_str_has_prefix(url, "file:/"));
+
+    url = lr_prepend_url_protocol("relative/path/does/not/exist");
+    fail_if(url != NULL);
+}
+END_TEST
+
+Suite *
+util_deprecated_suite(void)
+{
+    Suite *s = suite_create("util_deprecated");
+    TCase *tc = tcase_create("Main");
+    tcase_add_test(tc, test_prepend_url_protocol);
+    suite_add_tcase(s, tc);
+    return s;
+}

--- a/tests/test_util_deprecated.h
+++ b/tests/test_util_deprecated.h
@@ -1,0 +1,8 @@
+#ifndef LR_TEST_UTIL_DEPRECATED_H
+#define LR_TEST_UTIL_DEPRECATED_H
+
+#include <check.h>
+
+Suite *util_deprecated_suite(void);
+
+#endif


### PR DESCRIPTION
This is a second attempt at #88.

This version avoids causing segfaults due to changing a public ABI without bumping soname.  It also avoids breaking the public API (requiring a flag day in users of the specific API).

Instead, a new function is added.  The existing one is rewritten as a wrapper to the old one, and still passes the tests.  The existing function is marked as deprecated, for maximum clarity.

There are known users of the API who will see deprecation warnings.  To remove the warnings, they will need a change which depends on this version of librepo.  This pull-request does not co-ordinate any such changes.