### PR TITLE
Fix typo: correct LRO_SSLVERIFYHOST with CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -629,7 +629,7 @@ lr_handle_setopt(LrHandle *handle,
 
     case LRO_SSLVERIFYHOST:
         handle->sslverifyhost = va_arg(arg, long) ? 2 : 0;
-        c_rc = curl_easy_setopt(c_h, CURLOPT_SSL_VERIFYPEER, handle->sslverifyhost);
+        c_rc = curl_easy_setopt(c_h, CURLOPT_SSL_VERIFYHOST, handle->sslverifyhost);
         break;
 
     case LRO_SSLCLIENTCERT:


### PR DESCRIPTION
In commit 51d32c6cd88ba0139c32793183fd6a236c1ef456
---
Author: Tomas Mlcoch <tmlcoch@redhat.com>
Date:   Mon May 5 14:31:35 2014 +0200

    Add LRO_SSLVERIFYPEER and LRO_SSLVERIFYHOST options (RhBug: 1093014)
---

It incorrectly setopt CURLOPT_SSL_VERIFYPEER for LRO_SSLVERIFYHOST.
Use CURLOPT_SSL_VERIFYHOST to correct.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>