### PR TITLE
build: support installation in alternate dir

### DIFF
--- a/librepo/python/python2/CMakeLists.txt
+++ b/librepo/python/python2/CMakeLists.txt
@@ -1,6 +1,11 @@
 FIND_PACKAGE (PythonLibs 2 )
 FIND_PACKAGE (PythonInterp 2 REQUIRED)
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 INCLUDE_DIRECTORIES (${PYTHON_INCLUDE_PATH})
 
 MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")

--- a/librepo/python/python3/CMakeLists.txt
+++ b/librepo/python/python3/CMakeLists.txt
@@ -10,7 +10,12 @@ message("--- ${PYTHON_INCLUDE_DIR}")
 
 FIND_PACKAGE(PythonLibs 3.0)
 FIND_PACKAGE(PythonInterp 3.0 REQUIRED)
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 INCLUDE_DIRECTORIES (${PYTHON_INCLUDE_PATH})
 
 MESSAGE(STATUS "Python3 install dir is ${PYTHON_INSTALL_DIR}")


### PR DESCRIPTION
This is the same modification as
https://github.com/rpm-software-management/libdnf/pull/136, but for this
repo. It allows one to build and install in an unprivileged dir.