### PR TITLE
headers: fix function declaration isn't a prototype

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -80,7 +80,7 @@ lr_handle_free_list(char ***list)
 }
 
 LrHandle *
-lr_handle_init()
+lr_handle_init(void)
 {
     LrHandle *handle;
     CURL *curl = lr_get_curl_handle();

--- a/librepo/handle.h
+++ b/librepo/handle.h
@@ -434,7 +434,7 @@ typedef enum {
  * @return              New allocated handle.
  */
 LrHandle *
-lr_handle_init();
+lr_handle_init(void);
 
 /** Frees handle and its content.
  * @param handle        Handle.

--- a/librepo/metalink.c
+++ b/librepo/metalink.c
@@ -106,7 +106,7 @@ lr_free_metalinkalternate(LrMetalinkAlternate *metalinkalternate)
 }
 
 LrMetalink *
-lr_metalink_init()
+lr_metalink_init(void)
 {
     return lr_malloc0(sizeof(LrMetalink));
 }

--- a/librepo/metalink.h
+++ b/librepo/metalink.h
@@ -67,7 +67,7 @@ typedef struct {
  * @return              New metalink object.
  */
 LrMetalink *
-lr_metalink_init();
+lr_metalink_init(void);
 
 /** Parse metalink file.
  * @param metalink          Metalink object.

--- a/librepo/mirrorlist.c
+++ b/librepo/mirrorlist.c
@@ -33,7 +33,7 @@
 #define BUF_LEN 4096
 
 LrMirrorlist *
-lr_mirrorlist_init()
+lr_mirrorlist_init(void)
 {
     return lr_malloc0(sizeof(LrMirrorlist));
 }

--- a/librepo/mirrorlist.h
+++ b/librepo/mirrorlist.h
@@ -40,7 +40,7 @@ typedef struct {
  * @return              New empty mirrorlist.
  */
 LrMirrorlist *
-lr_mirrorlist_init();
+lr_mirrorlist_init(void);
 
 /**
  * Parse mirrorlist file.

--- a/librepo/repomd.c
+++ b/librepo/repomd.c
@@ -55,7 +55,7 @@ lr_yum_repomdrecord_free(LrYumRepoMdRecord *rec)
 }
 
 LrYumRepoMd *
-lr_yum_repomd_init()
+lr_yum_repomd_init(void)
 {
     LrYumRepoMd *repomd = lr_malloc0(sizeof(*repomd));
     repomd->chunk = g_string_chunk_new(32);

--- a/librepo/repomd.h
+++ b/librepo/repomd.h
@@ -75,7 +75,7 @@ typedef struct {
  * @return              New repomd object.
  */
 LrYumRepoMd *
-lr_yum_repomd_init();
+lr_yum_repomd_init(void);
 
 /** Free repomd content and repomd object itself.
  * @param repomd        Repomd object.

--- a/librepo/result.c
+++ b/librepo/result.c
@@ -32,7 +32,7 @@
 #include "repomd.h"
 
 LrResult *
-lr_result_init()
+lr_result_init(void)
 {
     return lr_malloc0(sizeof(struct _LrResult));
 }

--- a/librepo/result.h
+++ b/librepo/result.h
@@ -60,7 +60,7 @@ typedef enum {
  * @return          New allocated ::LrResult object
  */
 LrResult *
-lr_result_init();
+lr_result_init(void);
 
 /** Clean result object.
  * @param result    Result object.

--- a/librepo/util.c
+++ b/librepo/util.c
@@ -69,7 +69,7 @@ lr_init_debugging(void)
 }
 
 void
-lr_log_librepo_summary()
+lr_log_librepo_summary(void)
 {
     _cleanup_free_ gchar *time = NULL;
     _cleanup_date_time_unref_ GDateTime *datetime = NULL;
@@ -96,7 +96,7 @@ lr_init_once_cb(gpointer user_data G_GNUC_UNUSED)
 }
 
 void
-lr_global_init()
+lr_global_init(void)
 {
     static GOnce init_once = G_ONCE_INIT;
     g_once(&init_once, lr_init_once_cb, NULL);
@@ -112,7 +112,7 @@ lr_global_cleanup()
 */
 
 void
-lr_out_of_memory()
+lr_out_of_memory(void)
 {
     fprintf(stderr, "Out of memory\n");
     abort();
@@ -150,7 +150,7 @@ lr_free(void *m)
 }
 
 int
-lr_gettmpfile()
+lr_gettmpfile(void)
 {
     int fd;
     _cleanup_free_ char *template = NULL;
@@ -165,7 +165,7 @@ lr_gettmpfile()
 }
 
 char *
-lr_gettmpdir()
+lr_gettmpdir(void)
 {
     char *template = g_build_filename(g_get_tmp_dir(), "librepo-tmpdir-XXXXXX", NULL);
     if (!mkdtemp(template)) {

--- a/librepo/util.h
+++ b/librepo/util.h
@@ -52,7 +52,7 @@ G_BEGIN_DECLS
  * This is called automatically to initialize librepo.
  * You normally don't have to call this function manually.
  */
-void lr_global_init();
+void lr_global_init(void);
 
 /** Clean up librepo library.
 void lr_global_cleanup();
@@ -65,7 +65,7 @@ void lr_log_librepo_summary(void);
 /** Print "Out of memory" message to stderr and abort program execution.
  * This function is used when malloc call fails.
  */
-void lr_out_of_memory();
+void lr_out_of_memory(void);
 
 /** Allocate len bytes of memory.
  * @param len           Number of bytes to be allocated.
@@ -94,12 +94,12 @@ void lr_free(void *mem);
 /** Create temporary librepo file in /tmp directory.
  * @return              File descriptor.
  */
-int lr_gettmpfile();
+int lr_gettmpfile(void);
 
 /** Create temporary directory in /tmp directory.
  * @return              Path to directory.
  */
-char *lr_gettmpdir();
+char *lr_gettmpdir(void);
 
 /** Concatenate all of given part of path.
  * If last chunk is "" then separator will be appended to the result.

--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -48,7 +48,7 @@
 /* helper functions for YumRepo manipulation */
 
 LrYumRepo *
-lr_yum_repo_init()
+lr_yum_repo_init(void)
 {
     return lr_malloc0(sizeof(LrYumRepo));
 }

--- a/librepo/yum.h
+++ b/librepo/yum.h
@@ -56,7 +56,7 @@ typedef struct {
  * @return              New yum repo object.
  */
 LrYumRepo *
-lr_yum_repo_init();
+lr_yum_repo_init(void);
 
 /** Free yum repo - free its item and the repo itself.
  * @param repo          Yum repo object.


### PR DESCRIPTION
The correct way to declare a function that takes no arguments is:

    int foo(void);

If we instead use

    int foo();

it means that `foo` takes an unspecified amount of arguments. GCC/clang
will complain about this declaration style nowadays if
`-Wstrict-prototypes` is turned on.