### PR TITLE
Fix max download speed from repo (RhBug:1227921)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Patrick Uiterwijk <puiterwijk@gmail.com>
 Neal Gompa <ngompa13@gmail.com>
 Martin Hatina <mhatina@redhat.com>
+Jaroslav Rohel <jrohel@redhat.com>


### PR DESCRIPTION
Max download speed was computed incorrectly during parallel transfer
from more repositories. Max speed for first repository was uniformly distributed
between all downloads (was used for all repositories).
Now max speed for each repository is uniformly distributed between downloads
which belongs to this repository.