### PR TITLE
Fix compilation with older glibc

### DIFF
--- a/librepo/metadata_downloader.c
+++ b/librepo/metadata_downloader.c
@@ -18,8 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#define _POSIX_SOURCE
-#define _DEFAULT_SOURCE
+#define _GNU_SOURCE // for SA_RESTART
 
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
Fixed error: 'SA_RESTART' undeclared