### PR TITLE
Reports initial downloads to the screen (RhBug:1483859)

### DIFF
--- a/librepo.spec
+++ b/librepo.spec
@@ -7,9 +7,10 @@
 %bcond_without python3
 %bcond_without tests
 %endif
+%global dnf_conflict 2.8.8
 
 Name:           librepo
-Version:        1.8.1
+Version:        1.9.0
 Release:        1%{?dist}
 Summary:        Repodata downloading library
 
@@ -51,6 +52,7 @@ BuildRequires:  python-nose
 BuildRequires:  python-sphinx
 BuildRequires:  pyxattr
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Conflicts:      python2-dnf < %{dnf_conflict}
 
 %description -n python2-%{name}
 Python 2 bindings for the librepo library.
@@ -69,6 +71,7 @@ BuildRequires:  python3-nose
 BuildRequires:  python3-sphinx
 BuildRequires:  python3-pyxattr
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+Conflicts:      python3-dnf < %{dnf_conflict}
 
 %description -n python3-%{name}
 Python 3 bindings for the librepo library.

--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -42,6 +42,7 @@
 #include "handle_internal.h"
 #include "cleanup.h"
 #include "url_substitution.h"
+#include "yum_internal.h"
 
 volatile sig_atomic_t lr_interrupt = 0;
 
@@ -2193,33 +2194,7 @@ lr_download_target(LrDownloadTarget *target,
 gboolean
 lr_download_url(LrHandle *lr_handle, const char *url, int fd, GError **err)
 {
-    gboolean ret;
-    LrDownloadTarget *target;
-    GError *tmp_err = NULL;
-
-    assert(url);
-    assert(!err || *err == NULL);
-
-    // Prepare target
-    target = lr_downloadtarget_new(lr_handle,
-                                   url, NULL, fd, NULL,
-                                   NULL, 0, 0, NULL, NULL,
-                                   NULL, NULL, NULL, 0, 0, FALSE);
-
-    // Download the target
-    ret = lr_download_target(target, &tmp_err);
-
-    assert(ret || tmp_err);
-    assert(!(target->err) || !ret);
-
-    if (!ret)
-        g_propagate_error(err, tmp_err);
-
-    lr_downloadtarget_free(target);
-
-    lseek(fd, 0, SEEK_SET);
-
-    return ret;
+    return lr_yum_download_url(lr_handle, url, fd, FALSE, err);
 }
 
 int

--- a/librepo/python/downloader-py.c
+++ b/librepo/python/downloader-py.c
@@ -64,6 +64,7 @@ py_download_url(G_GNUC_UNUSED PyObject *self, PyObject *args)
 
     if (HandleObject_Check(py_handle)) {
         handle = Handle_FromPyObject(py_handle);
+        Handle_SetThreadState(py_handle, &state);
     } else if (py_handle != Py_None) {
         PyErr_SetString(PyExc_TypeError, "Only Handle or None is supported");
         return NULL;

--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -465,6 +465,45 @@ lr_get_metadata_failure_callback(const LrHandle *handle)
     return cbdata;
 }
 
+gboolean
+lr_yum_download_url(LrHandle *lr_handle, const char *url, int fd, gboolean no_cache, GError **err)
+{
+    gboolean ret;
+    LrDownloadTarget *target;
+    GError *tmp_err = NULL;
+
+    assert(url);
+    assert(!err || *err == NULL);
+
+    CbData *cbdata = cbdata_new(lr_handle->user_data,
+                                NULL,
+                                lr_handle->user_cb,
+                                lr_handle->hmfcb,
+                                url);
+
+    // Prepare target
+    target = lr_downloadtarget_new(lr_handle,
+                                   url, NULL, fd, NULL,
+                                   NULL, 0, 0,(lr_handle->user_cb) ? progresscb : NULL, cbdata,
+                                   NULL, (lr_handle->hmfcb) ? hmfcb : NULL, NULL, 0, 0, no_cache);
+
+    // Download the target
+    ret = lr_download_target(target, &tmp_err);
+
+    assert(ret || tmp_err);
+    assert(!(target->err) || !ret);
+    cbdata_free(cbdata);
+
+    if (!ret)
+        g_propagate_error(err, tmp_err);
+
+    lr_downloadtarget_free(target);
+
+    lseek(fd, 0, SEEK_SET);
+
+    return ret;
+}
+
 static gboolean
 lr_yum_download_repomd(LrHandle *handle,
                        LrMetalink *metalink,
@@ -483,7 +522,11 @@ lr_yum_download_repomd(LrHandle *handle,
         lr_get_best_checksum(metalink, &checksums);
     }
 
-    CbData *cbdata = lr_get_metadata_failure_callback(handle);
+    CbData *cbdata = cbdata_new(handle->user_data,
+                            NULL,
+                            handle->user_cb,
+                            handle->hmfcb,
+                            "repomd.xml");
 
     LrDownloadTarget *target = lr_downloadtarget_new(handle,
                                                      "repodata/repomd.xml",
@@ -493,10 +536,10 @@ lr_yum_download_repomd(LrHandle *handle,
                                                      checksums,
                                                      0,
                                                      0,
-                                                     NULL,
+                                                     (handle->user_cb) ? progresscb : NULL,
                                                      cbdata,
                                                      NULL,
-                                                     (cbdata) ? hmfcb : NULL,
+                                                     (handle->hmfcb) ? hmfcb : NULL,
                                                      NULL,
                                                      0,
                                                      0,

--- a/librepo/yum_internal.h
+++ b/librepo/yum_internal.h
@@ -31,6 +31,8 @@ G_BEGIN_DECLS
 
 gboolean
 lr_yum_perform(LrHandle *handle, LrResult *result, GError **err);
+gboolean
+lr_yum_download_url(LrHandle *lr_handle, const char *url, int fd, gboolean no_cache, GError **err);
 
 G_END_DECLS
 


### PR DESCRIPTION
The first downloads like metalink, and repomd.xml were perform silently.

https://bugzilla.redhat.com/show_bug.cgi?id=1483859