### PR TITLE
Support for md5 checksums fixed.

### DIFF
--- a/librepo/checksum.c
+++ b/librepo/checksum.c
@@ -57,7 +57,7 @@ lr_checksum_type(const char *type)
     if (!strncmp(type_lower, "md", 2)) {
         // MD* family
         char *md_type = type_lower + 2;
-        if (strcmp(md_type, "5"))
+        if (!strcmp(md_type, "5"))
             return LR_CHECKSUM_MD5;
     } else if (!strncmp(type_lower, "sha", 3)) {
         // SHA* family


### PR DESCRIPTION
I found a bug. dnf can not synchronize a repository if it is signed with md5. Here is the error:

`librepo.LibrepoException: (21, 'Unknown checksum type "md5" for /var/lib/mock/[...]/[...]-filelists.xml.gz', 'Unknown type of checksum is needed to verify one or more file(s)')
`

So I made this patch. I hope it will be useful.