### PR TITLE
Fix: support of pygpgme with Python3

### DIFF
--- a/tests/python/tests/base.py
+++ b/tests/python/tests/base.py
@@ -36,8 +36,6 @@ except ImportError:
             self.ctx.armor = value
 
         def op_import(self, key_fo):
-            if isinstance(key_fo, basestring):
-                key_fo = io.BytesIO(key_fo)
             self.ctx.import_(key_fo)
 
         def op_export(self, pattern, mode, keydata):


### PR DESCRIPTION
Removes unneeded code which depends on Python2.
Both python-gpg and pygpgme works with Python2 and Python3 now.