### PR TITLE
Fix progress reporting with zchunk files

### DIFF
--- a/librepo/downloadtarget.h
+++ b/librepo/downloadtarget.h
@@ -152,6 +152,12 @@ typedef struct {
 
     gint64 zck_header_size; /*!<
         Zchunk header size */
+
+    double total_to_download; /*!<
+        Total to download in zchunk file */
+
+    double downloaded; /*!<
+        Amount already downloaded in zchunk file */
     #endif /* WITH_ZCHUNK */
 
 } LrDownloadTarget;


### PR DESCRIPTION
Currently, when downloading a zchunk file, the progress bar gets reset to
zero when the header is finished downloading.  This patch fixes that bug.

Signed-off-by: Jonathan Dieter <jdieter@gmail.com>