### PR TITLE
Only automatically download zchunk metadata for main metadata

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -81,7 +81,10 @@ lr_yum_repo_free(LrYumRepo *repo)
 static char *
 get_type(LrYumRepo *repo, const char *type)
 {
-    if (!repo->use_zchunk)
+    if (!repo->use_zchunk ||
+        (g_strcmp0(type, "primary") != 0 &&
+         g_strcmp0(type, "filelists") != 0 &&
+         g_strcmp0(type, "other") != 0))
         return g_strdup(type);
 
     gchar *chk_type = g_strconcat(type, "_zck", NULL);
@@ -177,6 +180,13 @@ lr_yum_switch_to_zchunk(LrHandle *handle, LrYumRepoMd *repomd)
     if (handle->yumdlist) {
         int x = 0;
         while (handle->yumdlist[x]) {
+            if(g_strcmp0(handle->yumdlist[x], "primary") != 0 &&
+               g_strcmp0(handle->yumdlist[x], "filelists") != 0 &&
+               g_strcmp0(handle->yumdlist[x], "other") != 0) {
+                x++;
+                continue;
+            }
+
             char *check_type = g_strconcat(handle->yumdlist[x], "_zck", NULL);
             assert(check_type);
 


### PR DESCRIPTION
Currently librepo attempts to download any available zchunk repodata if libdnf supports zchunk.  Unfortunately, as can be seen in https://pagure.io/dusty/failed-composes/issue/1529, there are situations where libdnf supports zchunk, but the calling application (in this case, dnf) doesn't.

This patch fixes librepo to only _automatically_ request zchunk repodata if it's `primary`, `filelists` or `other`, since those are automatically decompressed by libsolv, which does support zchunk.  If the calling application supports zchunk, it can manually request the zchunk variant of a record from librepo and then failover itself if that record doesn't exist.