### PR TITLE
fix test_download_packages_with_resume_02 test

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -760,7 +760,7 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
         pkg = pkgs[0]
         self.assertTrue(pkg.err)
         self.assertTrue(os.path.isfile(pkg.local_path))
-        self.assertEqual(open(pkg.local_path, "rb").read(), CONTENT)
+        self.assertEqual(open(pkg.local_path, "rb").read(), CONTENT.encode('utf-8'))
 
     def test_download_packages_mirror_penalization_01(self):
 


### PR DESCRIPTION
This patch fixes:
AssertionError: b'0123456789' != '0123456789'