### PR TITLE
Fix librepo isn't able to load zchunk files from next server on failure

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -2326,8 +2326,14 @@ transfer_error:
                   g_error_free(transfer_err);  // Ignore the error
 
                   // Truncate file - remove downloaded garbage (error html page etc.)
-                  if (!truncate_transfer_file(target, err))
-                      return FALSE;
+                  #ifdef WITH_ZCHUNK
+                  if (!target->target->is_zchunk || target->zck_state == LR_ZCK_DL_HEADER) {
+                  #endif
+                    if (!truncate_transfer_file(target, err))
+                        return FALSE;
+                  #ifdef WITH_ZCHUNK
+                  }
+                  #endif
                 }
             }
 


### PR DESCRIPTION
Zchunk uses a simple state machine in librepo to determine where it's at
in the download process (is it downloading the header or the body).

The yandex.ru mirror will fail if more than one range is in a request, but
fails in a nonstandard way.  librepo catches the failure and moves on to
the next mirror, but truncates the downloaded zchunk header.  This causes
the state machine to be out of sync with reality.

I've fixed this by only truncating the zchunk header if the state machine is
in the header download state, which means that the next mirror will only
download any missing chunks.  Zchunk will only download missing or
corrupted chunks, so this also gives us automatic resume on zchunk
metadata downloads.

See https://bugzilla.redhat.com/show_bug.cgi?id=1706321 for the initial bug
report.  Please pull this into F30, as our Russian users are running into
problems because of this bug.