### PR TITLE
Make sure to check next transfer if current zck transfer already exists

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1450,7 +1450,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
             goto fail;
         }
 
-        // If zchunk is finished, we're done
+        // If zchunk is finished, we're done, so move to next target
         if(target->zck_state == LR_ZCK_DL_FINISHED) {
             g_debug("%s: Target already fully downloaded: %s", __func__, target->target->path);
             target->state = LR_DS_FINISHED;
@@ -1461,7 +1461,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
             fclose(target->f);
             target->f = NULL;
             lr_downloadtarget_set_error(target->target, LRE_OK, NULL);
-            return TRUE;
+            return prepare_next_transfer(dd, candidatefound, err);
         }
     }
     # endif /* WITH_ZCHUNK */


### PR DESCRIPTION
Currently, if prepare_next_transfer finds a complete zchunk file, it returns TRUE without moving on to the next file, which communicates to the thread that all downloads are done.

Luckily for us, there are normally other threads to finish downloading, but, if ```max_parallel_downloads``` is set to 1 in /etc/dnf/dnf.conf, this will have dnf fail to download the remaining metadata (whether zchunk or not) with the rather unhelpful error message: Not finished.

This patch fixes ```prepare_next_transfer``` to recursively check until it runs out of files to download or it finds an incomplete zchunk file.

This fixes RHBZ #1706627