### PR TITLE
Exit gpg-agent after repokey import (RhBug:1650266)

### DIFF
--- a/librepo/gpg.c
+++ b/librepo/gpg.c
@@ -255,18 +255,6 @@ lr_gpg_import_key(const char *key_fn, const char *home_dir, GError **err)
             gpgme_release(context);
             return FALSE;
         }
-
-        // It configures the gpg agent to run in server mode and to wait for stdin commands.
-        // The default gpg agent mode is to create a socket and listen for commands there.
-        gchar * gpg_agent_conf_fn = g_strconcat(home_dir, "/gpg-agent.conf", NULL);
-        int confFd = open(gpg_agent_conf_fn,
-                          O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-        g_free(gpg_agent_conf_fn);
-        if (confFd != -1) {
-            const char * const agentConfig = "server\n";
-            write(confFd, agentConfig, strlen(agentConfig));
-            close(confFd);
-        }
     }
 
     gpgme_set_armor(context, 1);


### PR DESCRIPTION
It tries to exit gpg-agent. Path to the communication socket is derived from homedir. The gpg-agent automaticaly removes all its socket before exit.
Newer gpg-agent creates sockets under [/var]/run/user/{pid}/... if directory exists. In this case gpg-agent will not be exited.
It solves the https://bugzilla.redhat.com/show_bug.cgi?id=1650266 issue of remaining sockets in the gpg home directory.

This PR replaces another solution https://github.com/rpm-software-management/librepo/pull/152 that configures the gpg agent to run in server mode (without sockets). Importing of repo keys was very slow  with gpg-agent in server mode during the unit tests.