### PR TITLE
Handle webservers that don't support ranges when downloading zck

### DIFF
--- a/librepo/downloadtarget.c
+++ b/librepo/downloadtarget.c
@@ -100,6 +100,7 @@ lr_downloadtarget_new(LrHandle *handle,
     target->fn              = lr_string_chunk_insert(target->chunk, fn);
     target->checksums       = possiblechecksums;
     target->expectedsize    = expectedsize;
+    target->origsize        = expectedsize;
     target->resume          = resume;
     target->progresscb      = progresscb;
     target->cbdata          = cbdata;

--- a/librepo/downloadtarget.h
+++ b/librepo/downloadtarget.h
@@ -88,6 +88,10 @@ typedef struct {
     gint64 expectedsize; /*!<
         Expected size of the target */
 
+    gint64 origsize; /*!<
+        Original expected size of the target.  Sometimes expectedsize will
+        change, especially if zchunk is in use, but this will never change */
+
     gboolean resume; /*!<
         Resume:
          0  - no resume, download whole file,


### PR DESCRIPTION
Make sure we fall back to downloading full zchunk file if a webserver doesn't support ranges.  Current code just fails to next mirror.