### PR TITLE
Define LRO_SUPPORTS_CACHEDIR only with zchunk (RhBug:1726141)

### DIFF
--- a/librepo/handle.h
+++ b/librepo/handle.h
@@ -37,9 +37,11 @@ G_BEGIN_DECLS
  */
 typedef struct _LrHandle LrHandle;
 
+#ifdef WITH_ZCHUNK
 /** Define LRO_SUPPORTS_CACHEDIR so clients can check for this feature at build
  * time */
 #define LRO_SUPPORTS_CACHEDIR
+#endif /* WITH_ZCHUNK */
 
 /** LRO_FASTESTMIRRORMAXAGE default value */
 #define LRO_FASTESTMIRRORMAXAGE_DEFAULT     2592000L // 30 days


### PR DESCRIPTION
LRO_CACHEDIR is used to define if the repos could be downloaded with
zchunk. LRO_SUPPORTS_CACHEDIR was used to determine if the librepo is
ready to zchunk.

It is a build option therefore it requires rebuild of libdnf.

https://bugzilla.redhat.com/show_bug.cgi?id=1726141