### PR TITLE
Adjust test for a new behavior of retrying mirrors

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -725,6 +725,7 @@ class TestCaseYumPackagesDownloading(TestCaseWithFlask):
         url = "%s%s" % (self.MOCKURL, config.REPO_YUM_01_PATH)
         h.urls = [url]
         h.repotype = librepo.LR_YUMREPO
+        h.allowedmirrorfailures = 1
 
         fn = os.path.join(self.tmpdir, "package.rpm")
 


### PR DESCRIPTION
The test tested that after failed download the resumed file exist with
original content. The original code removed unfinished file before a
second attempt to download removed unfinished file. The new
implementation tries mirrosrs up to allowedmirrorfailures, therefore it
resulted in removal of file before the second try.