### PR TITLE
Unit tests for correctly appending path in URLs with arguments

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -142,6 +142,27 @@ class TestCaseYumPackageDownloading(TestCaseWithFlask):
         pkg = os.path.join(self.tmpdir, config.PACKAGE_01_01)
         self.assertTrue(os.path.isfile(pkg))
 
+    def test_download_package_with_baseurl_and_arguments(self):
+        """
+        Tests that the path is correctly joined with a baseurl that has a
+        http argument after a question mark.
+        """
+        h = librepo.Handle()
+
+        url = "%s%s" % (self.MOCKURL, config.BADURL)
+        baseurl = "%s%s?hello=1" % (self.MOCKURL, config.REPO_YUM_01_PATH)
+        h.urls = [url]
+        h.repotype = librepo.LR_YUMREPO
+        h.destdir = self.tmpdir
+        h.checksum = True
+        h.download(config.PACKAGE_01_01,
+                   checksum=config.PACKAGE_01_01_SHA256,
+                   checksum_type=librepo.CHECKSUM_SHA256,
+                   base_url=baseurl)
+
+        pkg = os.path.join(self.tmpdir, config.PACKAGE_01_01)
+        self.assertTrue(os.path.isfile(pkg))
+
 class TestCaseYumPackagesDownloading(TestCaseWithFlask):
     application = app
 

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -94,6 +94,18 @@ START_TEST(test_pathconcat)
     fail_if(strcmp(path, "foo/bar/"));
     lr_free(path);
     path = NULL;
+
+    path = lr_pathconcat("http://host.net", "path/to/somewhere", NULL);
+    fail_if(path == NULL);
+    fail_if(strcmp(path, "http://host.net/path/to/somewhere"));
+    lr_free(path);
+    path = NULL;
+
+    path = lr_pathconcat("http://host.net?hello=1", "path/to/", "somewhere", NULL);
+    fail_if(path == NULL);
+    fail_if(strcmp(path, "http://host.net/path/to/somewhere?hello=1"));
+    lr_free(path);
+    path = NULL;
 }
 END_TEST
 


### PR DESCRIPTION
Tests for the case when there are http arguments after a question mark in e.g. baseurl to which a path is appended.