### PR TITLE
Rephrase repository GPG check error message

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -468,12 +468,11 @@ lr_check_repomd_xml_asc_availability(LrHandle *handle,
         lr_free(url);
         close(fd_sig);
         if (!ret) {
-            // Signature doesn't exist
-            g_debug("%s: GPG signature doesn't exists: %s",
-                    __func__, tmp_err->message);
+            // Error downloading signature
             g_set_error(err, LR_YUM_ERROR, LRE_BADGPG,
                         "GPG verification is enabled, but GPG signature "
-                                "repomd.xml.asc is not available: %s", tmp_err->message);
+                        "is not available. This may be an error or the "
+                        "repository does not support GPG verification: %s", tmp_err->message);
             g_clear_error(&tmp_err);
             unlink(signature);
             lr_free(signature);
@@ -1165,10 +1164,10 @@ lr_yum_use_local_load_base(LrHandle *handle,
 
         if (!repo->signature) {
             // Signature doesn't exist
-            g_debug("%s: GPG signature doesn't exists", __func__);
             g_set_error(err, LR_YUM_ERROR, LRE_BADGPG,
                         "GPG verification is enabled, but GPG signature "
-                        "repomd.xml.asc is not available");
+                        "repomd.xml.asc is not available. This may be an "
+                        "error or the repository does not support GPG verification.");
             return FALSE;
         }
 


### PR DESCRIPTION
The user may enable the repo_gpgcheck config option, unknowing the
repository doesn't support GPG verification. Rephrase the error to make
it clearer that not finding the signature file may mean GPG verification
is not supported.

I've also removed the debug messages that accompanied the errors, as
they seem redundant with the error messages.

This is still a bit awkward, as the HTTP download may fail on other
errors than 404, which should be clearly differentiated as server
error and not talk about GPG support.

https://bugzilla.redhat.com/show_bug.cgi?id=1741442

---
Getting this message through to the user required changes in `libdnf` and `dnf` as well. Links will be in a comment.

The original output of dnf for the error is like this:
```
# dnf reposync
...
Failed to download metadata for repo 'updates'
Error: Failed to download metadata for repo 'updates'
# dnf reposync -v
... a lot of output, including 8 total lines of "error: Status code: 404 for THE_FILE
Cannot download 'https://mirrors.fedoraproject.org/metalink?repo=updates-released-f30&arch=x86_64': GPG verification is enabled, but GPG signature repomd.xml.asc is not available: Status code: 404 for http://ftp.fi.muni.cz/pub/linux/fedora/linux/updates/30/Everything/x86_64/repodata/repomd.xml.asc.
Failed to download metadata for repo 'updates'
Error: Failed to download metadata for repo 'updates'
```

After the patches:
```
# dnf reposync
Error: Failed to download metadata for repo 'updates': GPG verification is enabled, but GPG signature is not available. This may be an error or the repository does not support GPG verification: Status code: 404 for http://mirrors.nic.cz/fedora/linux/updates/30/Everything/x86_64/repodata/repomd.xml.asc
```

I'm not very happy about these patches, but the error message needs to be propagated from `librepo` all the way to `dnf` and displayed succintly... I've also done a couple of changes to how the messages are logged in various places, so other errors may be displayed differently and I can't be sure which (there are just a few in `ci-dnf-stack`).

I didn't add any version dependencies, as they are not strictly required, the error message just will be in various state of completeness depending on the combination of versions...

Requesting a review from @dmach as I remember he had an idea about the error message and I'm not sure I got it right.