### PR TITLE
misc: librepo/*.{c,h}: typo fixes.

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -112,12 +112,12 @@ typedef struct {
         Mirror */
     int allowed_parallel_connections; /*!<
         Maximum number of allowed parallel connections to this mirror. -1 means no limit.
-        Dynamicaly adjusted (decreased) if no fatal (temporary) error will occur. */
+        Dynamically adjusted (decreased) if no fatal (temporary) error will occur. */
     int max_tried_parallel_connections; /*!<
         The maximum number of tried parallel connections to this mirror
         (including unsuccessful). */
     int running_transfers; /*!<
-        How many transfers from this mirror are currently in progres. */
+        How many transfers from this mirror are currently in progress. */
     int successful_transfers; /*!<
         How many transfers was finished successfully from the mirror. */
     int failed_transfers; /*!<
@@ -511,7 +511,7 @@ lr_headercb(void *ptr, size_t size, size_t nmemb, void *userdata)
         } else if (lrtarget->protocol == LR_PROTOCOL_FTP) {
             // Headers of a FTP protocol
             if (g_str_has_prefix(header, "213 ")) {
-                // Code 213 shoud keep the file size
+                // Code 213 should keep the file size
                 gint64 content_length = g_ascii_strtoll(header+4, NULL, 0);
 
                 g_debug("%s: Server returned size: \"%s\" "
@@ -534,7 +534,7 @@ lr_headercb(void *ptr, size_t size, size_t nmemb, void *userdata)
                     lrtarget->headercb_state = LR_HCS_DONE;
                 }
             } else if (g_str_has_prefix(header, "150")) {
-                // Code 150 shoud keep the file size
+                // Code 150 should keep the file size
                 // TODO: See parse150 in /usr/lib64/python2.7/ftplib.py
             }
         }
@@ -676,7 +676,7 @@ lr_writecb(char *ptr, size_t size, size_t nmemb, void *userdata)
     assert(nmemb > 0);
     cur_written = fwrite(ptr, size, nmemb, target->f);
     if (cur_written != nmemb) {
-        g_debug("%s: Error while writting out file: %s",
+        g_debug("%s: Error while writing out file: %s",
                 __func__, g_strerror(errno));
         return 0; // There was an error
     }
@@ -695,7 +695,7 @@ select_suitable_mirror(LrDownload *dd,
 
     gboolean at_least_one_suitable_mirror_found = FALSE;
     //  ^^^ This variable is used to indentify that all possible mirrors
-    // were already tried and the transfer shoud be marked as failed.
+    // were already tried and the transfer should be marked as failed.
 
     assert(dd);
     assert(target);
@@ -708,10 +708,10 @@ select_suitable_mirror(LrDownload *dd,
     //  Iterate over mirrors for the target. If no suitable mirror is found on
     //  the first iteration, relax the conditions (by allowing previously
     //  failing mirrors to be used again) and do additional iterations up to
-    //  number af allowed failures equal to dd->allowed_mirror_failures.
+    //  number of allowed failures equal to dd->allowed_mirror_failures.
     do {
-        // Sleep when all mirrors were alredy tried
-        // It prevents to call same url inmediatly after fail
+        // Sleep when all mirrors were already tried
+        // It prevents to call same url immediately after fail
         if (mirrors_iterated) {
             sleep(mirrors_iterated);
         }
@@ -806,7 +806,7 @@ select_suitable_mirror(LrDownload *dd,
                 g_debug("%s: Downloading was aborted by LR_CB_ERROR "
                         "from end callback", __func__);
                 g_set_error(err, LR_DOWNLOADER_ERROR, LRE_CBINTERRUPTED,
-                        "Interupted by LR_CB_ERROR from end callback");
+                        "Interrupted by LR_CB_ERROR from end callback");
                 return FALSE;
             }
         }
@@ -927,7 +927,7 @@ select_next_target(LrDownload *dd,
                     g_debug("%s: Downloading was aborted by LR_CB_ERROR "
                             "from end callback", __func__);
                     g_set_error(err, LR_DOWNLOADER_ERROR, LRE_CBINTERRUPTED,
-                            "Interupted by LR_CB_ERROR from end callback");
+                            "Interrupted by LR_CB_ERROR from end callback");
                     return FALSE;
                 }
             }
@@ -959,7 +959,7 @@ select_next_target(LrDownload *dd,
 
 #define XATTR_LIBREPO   "user.Librepo.DownloadInProgress"
 
-/** Add an extendend attribute that indiciates that
+/** Add an extended attribute that indicates that
  * the file is being/was downloaded by Librepo
  */
 static void
@@ -1534,7 +1534,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     if (target->resume && target->resume_count >= LR_DOWNLOADER_MAXIMAL_RESUME_COUNT) {
         target->resume = FALSE;
-        g_debug("%s: Download resume ignored, maximal number of attemtps (%d)"
+        g_debug("%s: Download resume ignored, maximal number of attempts (%d)"
                 " has been reached", __func__, LR_DOWNLOADER_MAXIMAL_RESUME_COUNT);
     }
 
@@ -1565,7 +1565,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     // Add librepo extended attribute to the file
     // This xattr states that file is being downloaded by librepo
-    // This xattr is removed once the file is completly downloaded
+    // This xattr is removed once the file is completely downloaded
     // If librepo tries to resume a download, it checks if the xattr is present.
     // If it isn't the download is not resumed, but whole file is
     // downloaded again.
@@ -2190,9 +2190,9 @@ check_transfer_statuses(LrDownload *dd, GError **err)
                           CURLINFO_EFFECTIVE_URL,
                           &effective_url);
 
-        effective_url = g_strdup(effective_url); // Make the effetive url
-                                                  // persistent to survive
-                                                  // the curl_easy_cleanup()
+        effective_url = g_strdup(effective_url); // Make the effective url
+                                                 // persistent to survive
+                                                 // the curl_easy_cleanup()
 
         g_debug("%s: Transfer finished: %s (Effective url: %s)",
                 __func__, target->target->path, effective_url);
@@ -2263,7 +2263,7 @@ check_transfer_statuses(LrDownload *dd, GError **err)
             if (!ret) { // Error
                 g_propagate_prefixed_error(err, tmp_err, "Downloading from %s"
                         "was successful but error encountered while "
-                        "checksuming: ", effective_url);
+                        "checksumming: ", effective_url);
                 return FALSE;
             }
         #ifdef WITH_ZCHUNK
@@ -2354,7 +2354,7 @@ transfer_error:
 
             if (!fatal_error)
             {
-                // Temporary error (serious_error) during download occured and
+                // Temporary error (serious_error) during download occurred and
                 // another transfers are running or there are successful transfers
                 // and fewer failed transfers than tried parallel connections. It may be mirror is OK
                 // but accepts fewer parallel connections.
@@ -2456,7 +2456,7 @@ transfer_error:
                 target->state = LR_DS_FINISHED;
 
                 // Remove xattr that states that the file is being downloaded
-                // by librepo, because the file is now completly downloaded
+                // by librepo, because the file is now completely downloaded
                 // and the xattr is not needed (is is useful only for resuming)
                 remove_librepo_xattr(target->target);
 
@@ -2472,7 +2472,7 @@ transfer_error:
                                 "from end callback", __func__);
                         g_set_error(&fail_fast_error, LR_DOWNLOADER_ERROR,
                                     LRE_CBINTERRUPTED,
-                                    "Interupted by LR_CB_ERROR from end callback");
+                                    "Interrupted by LR_CB_ERROR from end callback");
                     }
                 }
                 if (target->mirror)
@@ -2529,7 +2529,7 @@ lr_perform(LrDownload *dd, GError **err)
             return FALSE;
         }
 
-        // Check if any handle finished and potentialy add one or more
+        // Check if any handle finished and potentially add one or more
         // waiting downloads to the multi_handle.
         int rc = check_transfer_statuses(dd, err);
         if (!rc)

--- a/librepo/downloadtarget.h
+++ b/librepo/downloadtarget.h
@@ -78,7 +78,7 @@ typedef struct {
     GSList *checksums; /*!<
         NULL or GSList with pointers to LrDownloadTargetChecksum
         structures. With possible checksums of the file.
-        Checksum check is stoped right after first match.
+        Checksum check is stopped right after first match.
         Useful in situation when the file could has one from set
         of available checksums.
         E.g. <mm0:alternates> element in metalink could contain alternate
@@ -108,7 +108,7 @@ typedef struct {
         (Use status to check if successfully or unsuccessfully) */
 
     LrMirrorFailureCb mirrorfailurecb; /*!<
-        Callen when download from a mirror failed. */
+        Called when download from a mirror failed. */
 
     GStringChunk *chunk; /*!<
         Chunk for strings used in this structure. */
@@ -177,7 +177,7 @@ typedef struct {
  *                          Note: Set this or fd, no both!
  * @param possiblechecksums NULL or GSList with pointers to
  *                          LrDownloadTargetChecksum structures. With possible
- *                          checksums of the file. Checksum check is stoped
+ *                          checksums of the file. Checksum check is stopped
  *                          right after first match. Useful in situation when
  *                          the file could has one from set of available
  *                          checksums.
@@ -186,7 +186,7 @@ typedef struct {
  *                          because metalink and mirrors could be out of
  *                          sync for a while.
  *                          Note: LrDownloadTarget takes responsibility
- *                          for destroing this list! So the list must not
+ *                          for destroying this list! So the list must not
  *                          be destroyed by the user, since it is passed
  *                          to this function.
  * @param expectedsize      Expected size of the target. If mirror reports
@@ -194,7 +194,7 @@ typedef struct {
  *                          If 0 then size of downloaded target is not checked.
  * @param resume            If FALSE, then no resume is done and whole file is
  *                          downloaded again. Otherwise offset will be
- *                          automaticaly detected from opened file descriptor
+ *                          automatically detected from opened file descriptor
  *                          by seek to the end.
  * @param progresscb        Progression callback or NULL
  * @param cbdata            Callback data or NULL

--- a/librepo/fastestmirror.c
+++ b/librepo/fastestmirror.c
@@ -38,6 +38,8 @@
 
 #define CACHE_GROUP_METADATA    ":_librepo_:"   // Group with metadata
 #define CACHE_KEY_TS            "ts"            // Timestamp
+// FIXME: next time the cache version is updated, please fix this typo! It
+// should obviously have been "connecttime".
 #define CACHE_KEY_CONNECTTIME   "connectime"    // Time of response
 #define CACHE_KEY_VERSION       "version"       // Version of cache format
 

--- a/librepo/handle.h
+++ b/librepo/handle.h
@@ -32,7 +32,7 @@ G_BEGIN_DECLS
  *  @{
  */
 
-/** Handle object containing configration for repository metadata and
+/** Handle object containing configuration for repository metadata and
  * package downloading.
  */
 typedef struct _LrHandle LrHandle;
@@ -201,7 +201,7 @@ typedef enum {
         If true, Librepo setups its own signal handler for SIGTERM and stops
         downloading if SIGTERM is catched. In this case current operation
         could return any kind of error code. Handle which operation was
-        interrupted shoud never be used again! */
+        interrupted should never be used again! */
 
     LRO_USERAGENT,  /*!< (char *)
         String for  User-Agent: header in the http request sent to
@@ -283,9 +283,9 @@ typedef enum {
     LRO_RPMMDBLIST = LRO_YUMBLIST,
 
     LRO_HMFCB, /*!< (LrHandleMirrorFailureCb)
-        Handle specific mirror failure callaback.
+        Handle specific mirror failure callback.
         Callback called when a repodata download from a mirror fails.
-        This callback gets the user data setted by LRO_PROGRESSDATA */
+        This callback gets the user data set by LRO_PROGRESSDATA */
 
     LRO_SSLVERIFYPEER, /*!< (long 1 or 0)
         This option determines whether librepo verifies the authenticity
@@ -334,7 +334,7 @@ typedef enum {
     LRO_OFFLINE, /*!< (long 1 or 0)
         Make the handle work only locally, all remote URLs are ignored.
         Remote mirrorlists/metalinks (if they are specified) are ignored.
-        Fastest mirror check (if enabled) is skiped. */
+        Fastest mirror check (if enabled) is skipped. */
 
     LRO_SSLCLIENTCERT, /*!< (char *)
         Path to the PEM format SSL client certificate librepo should use
@@ -350,7 +350,7 @@ typedef enum {
         certificates. */
 
     LRO_HTTPAUTHMETHODS, /*!< (LrAuth)
-        Bitmask which tell Librepo which auth metods you wan to use. */
+        Bitmask which tell Librepo which auth methods you wan to use. */
 
     LRO_PROXYAUTHMETHODS, /*!< (LrAuth)
         A long bitmask which tell Librepo which auth methods you want

--- a/librepo/handle_internal.h
+++ b/librepo/handle_internal.h
@@ -161,13 +161,13 @@ struct _LrHandle {
         the library to consider it too slow and abort. */
 
     LrHandleMirrorFailureCb hmfcb; /*!<
-        Callaback called when a repodata download from a mirror fails. */
+        Callback called when a repodata download from a mirror fails. */
 
     gint64 maxspeed; /*!<
         Max speed in bytes per sec */
 
     long sslverifypeer; /*!<
-        Determines whether verify the autenticity of the peer's certificate */
+        Determines whether verify the authenticity of the peer's certificate */
 
     long sslverifyhost; /*!<
         Determines whether the server name should be checked against the name
@@ -220,7 +220,7 @@ struct _LrHandle {
         Base cache dir for repositories */
 
     long preservetime; /*!<
-        Preserve timestapms of downloaded files */
+        Preserve timestamps of downloaded files */
 
     LrUrlVars *yumslist;
 };

--- a/librepo/package_downloader.c
+++ b/librepo/package_downloader.c
@@ -578,10 +578,10 @@ lr_check_packages(GSList *targets,
                     g_debug("%s: Package %s is already downloaded (checksum matches)",
                             __func__, packagetarget->local_path);
                 } else {
-                    // Checksum doesn't match or checksuming error
+                    // Checksum doesn't match or checksumming error
                     packagetarget->err = g_string_chunk_insert(
                                                 packagetarget->chunk,
-                                                "Checksum of doesn't match");
+                                                "Checksum of file doesn't match");
                     if (failfast) {
                         ret = FALSE;
                         g_set_error(err, LR_PACKAGE_DOWNLOADER_ERROR,

--- a/librepo/package_downloader.h
+++ b/librepo/package_downloader.h
@@ -46,7 +46,7 @@ G_BEGIN_DECLS
 
 /** Download package from repository or base_url.
  * Note: If resume, checksum and checksum_type are specified and
- * the downloaded package alredy exists and checksum matches, then
+ * the downloaded package already exists and checksum matches, then
  * no downloading is done and LRE_ALREADYDOWNLOADED return code is returned.
  * @param handle            Librepo handle.
  * @param relative_url      Relative part of url.
@@ -112,7 +112,7 @@ typedef struct {
         (Use status to check if successfully or unsuccessfully) */
 
     LrMirrorFailureCb mirrorfailurecb; /*!<
-        Callen when download from a mirror failed. */
+        Called when download from a mirror failed. */
 
     gint64 byterangestart; /*!<
         Download only specified range of bytes. */
@@ -253,7 +253,7 @@ lr_packagetarget_free(LrPackageTarget *target);
 /** Available flags for package downloader */
 typedef enum {
     LR_PACKAGEDOWNLOAD_FAILFAST    = 1 << 0, /*!<
-        If TRUE, then whole downloading is stoped immediately when any
+        If TRUE, then whole downloading is stopped immediately when any
         of download fails (FALSE is returned and err is set). If the failfast
         is FALSE, then this function returns after all downloads finish
         (no matter if successfully or unsuccessfully) and FALSE is returned

--- a/librepo/rcodes.h
+++ b/librepo/rcodes.h
@@ -118,7 +118,7 @@ typedef enum {
         (38) Requested option/value is not set. Used for example in
         lr_yum_repoconf_getinfo() */
     LRE_FILE, /*!<
-        (39) File operation error (operation not permited, filename too long,
+        (39) File operation error (operation not permitted, filename too long,
         no memory available, bad file descriptor, ...) */
     LRE_KEYFILE, /*!<
         (40) Key file error (unknown encoding, ill-formed, file not found,

--- a/librepo/repoconf.c
+++ b/librepo/repoconf.c
@@ -353,7 +353,7 @@ lr_convert_interval_to_seconds(const char *str,
     // String doesn't start with numbers
     if (endptr == str) {
         g_set_error(err, LR_REPOCONF_ERROR, LRE_VALUE,
-                    "Could't convert '%s' to seconds", str);
+                    "Couldn't convert '%s' to seconds", str);
         return FALSE;
     }
 
@@ -435,7 +435,7 @@ lr_convert_bandwidth_to_bytes(const char *str,
     // String doesn't start with numbers
     if (endptr == str) {
         g_set_error(err, LR_REPOCONF_ERROR, LRE_VALUE,
-                    "Could't convert '%s' to number", str);
+                    "Couldn't convert '%s' to number", str);
         return FALSE;
     }
 
@@ -741,7 +741,7 @@ lr_yum_repoconf_getinfo(LrYumRepoConf *repoconf,
         *strv = lr_key_file_get_string_list(keyfile, id, "gpgcakey", &tmp_err);
         break;
 
-    case LR_YRC_EXCLUDE:         /*!< (char **) List of exluded packages */
+    case LR_YRC_EXCLUDE:         /*!< (char **) List of excluded packages */
         strv = va_arg(arg, char ***);
         *strv = lr_key_file_get_string_list(keyfile, id, "exclude", &tmp_err);
         break;

--- a/librepo/repoconf.h
+++ b/librepo/repoconf.h
@@ -54,7 +54,7 @@ typedef enum {
     LR_YRC_MEDIAID,         /*!<  6 (char *) Media ID */
     LR_YRC_GPGKEY,          /*!<  7 (char **) URL of GPG key */
     LR_YRC_GPGCAKEY,        /*!<  8 (char **) GPG CA key */
-    LR_YRC_EXCLUDE,         /*!<  9 (char **) List of exluded packages */
+    LR_YRC_EXCLUDE,         /*!<  9 (char **) List of excluded packages */
     LR_YRC_INCLUDE,         /*!< 10 (char **) List of included packages */
 
     LR_YRC_FASTESTMIRROR,   /*!< 11 (long 1 or 0) Fastest mirror determination */
@@ -166,7 +166,7 @@ lr_yum_repoconf_save(LrYumRepoConf *repoconf,
  * @param err           GError **
  * @param option        An option
  * @param ...           Appropriate variable for the selected option.
- * @return              TRUE if everithing is ok, FALSE if err is set.
+ * @return              TRUE if everything is ok, FALSE if err is set.
  *                      Note value of the target variable passed as vararg
  *                      can be changed and it's state is undefined when
  *                      a FALSE is returned!

--- a/librepo/repomd.c
+++ b/librepo/repomd.c
@@ -186,7 +186,7 @@ typedef enum {
 } LrRepomdState;
 
 /* NOTE: Same states in the first column must be together!!!
-* Performance tip: More frequent elements shoud be listed
+* Performance tip: More frequent elements should be listed
 * first in its group (eg: element "package" (STATE_PACKAGE)
 * has a "file" element listed first, because it is more frequent
 * than a "version" element). */

--- a/librepo/types.h
+++ b/librepo/types.h
@@ -183,7 +183,7 @@ typedef enum {
 
     LR_FMSTAGE_DETECTION, /*!<
         Detection (pinging) in progress.
-        If all data was loaded from cache, this stage is skiped.
+        If all data was loaded from cache, this stage is skipped.
         ptr is pointer to long. This is the number of how much
         mirrors have to be "pinged" */
 

--- a/librepo/util.h
+++ b/librepo/util.h
@@ -122,7 +122,7 @@ int lr_remove_dir(const char *path);
 
 /** Copy content from source file descriptor to the dest file descriptor.
  * @param source        Source opened file descriptor
- * @param dest          Destination openede file descriptor
+ * @param dest          Destination opened file descriptor
  * @return              0 on succes, -1 on error
  */
 int lr_copy_content(int source, int dest);
@@ -144,7 +144,7 @@ char *lr_prepend_url_protocol(const char *path);
 gchar *
 lr_string_chunk_insert(GStringChunk *chunk, const gchar *string);
 
-/** Warning callback to print warrnings via GLib logger
+/** Warning callback to print warnings via GLib logger
  * For more info take a look at ::LrXmlParserWarningCb
  */
 int
@@ -155,7 +155,7 @@ lr_xml_parser_warning_logger(LrXmlParserWarningType type G_GNUC_UNUSED,
 
 
 /** From the GSList of pointers to LrMetalinkHash objects, select the
- * strognest one which librepo could calculate.
+ * strongest one which librepo could calculate.
  * @param list      List of LrMetalinkHash*
  * @param type      Variable to store checksum type.
  * @param value     Variable to store pointer to value (pointer to original
@@ -183,7 +183,7 @@ lr_strv_dup(gchar **array);
 
 
 /** Check if string looks like a local path.
- * (This function doesn't do realpath resolving and existency checking)
+ * (This function doesn't do realpath resolving and existence checking)
  * If a path is empty, NULL or has protocol other then file:// specified
  * then the path is considered as remote, otherwise TRUE is returned.
  * @param path      A string path

--- a/librepo/xmlparser.h
+++ b/librepo/xmlparser.h
@@ -49,7 +49,7 @@ typedef enum {
  * LR_CB_RET_OK then parsing is immediately interrupted.
  * @param type      Type of warning
  * @param msg       Warning msg. The message is destroyed after the call.
- *                  If you want touse the message later, you have to copy it.
+ *                  If you want to use the message later, you have to copy it.
  * @param cbdata    User data.
  * @param err       GError **
  * @return          LR_CB_RET_OK (0) or LR_CB_RET_ERR (1) - stops the parsing

--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -160,7 +160,7 @@ lr_yum_repo_update(LrYumRepo *repo, const char *type, const char *path)
     lr_yum_repo_append(repo, type, path);
 }
 
-/* main bussines logic */
+/* main business logic */
 
 gint
 compare_records(gconstpointer a, gconstpointer b)


### PR DESCRIPTION
Should, at most, change log output and error messages, otherwise be
non-functional.

One typo ("connectime") in the cache file format is not easily fixable
since that would have meant upgrading the cache version, but doing that
just for fixing a typo sounds stupid. Hence, let's leave a note for
later processing and hope for the best/that someone will actually
remember or read the note and act accordingly...