### PR TITLE
Fix calling Python API without holding GIL (RhBug:1788918)

### DIFF
--- a/librepo/python/handle-py.c
+++ b/librepo/python/handle-py.c
@@ -142,6 +142,8 @@ fastestmirror_callback(void *data, LrFastestMirrorStages stage, void *ptr)
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     if (!ptr) {
         pydata = Py_None;
     } else {
@@ -159,7 +161,6 @@ fastestmirror_callback(void *data, LrFastestMirrorStages stage, void *ptr)
         }
     }
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->fastestmirror_cb,
                         "(OlO)", user_data, (long) stage, pydata);
     Py_XDECREF(result);
@@ -187,11 +188,12 @@ hmf_callback(void *data, const char *msg, const char *url, const char *metadata)
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     py_msg = PyStringOrNone_FromString(msg);
     py_url = PyStringOrNone_FromString(url);
     py_metadata = PyStringOrNone_FromString(metadata);
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->hmf_cb,
                         "(OOOO)", user_data, py_msg, py_url, py_metadata);
 

--- a/librepo/python/metadatatarget-py.c
+++ b/librepo/python/metadatatarget-py.c
@@ -142,10 +142,11 @@ metadatatarget_mirrorfailure_callback(void *data,
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     py_msg = PyStringOrNone_FromString(msg);
     py_url = PyStringOrNone_FromString(url);
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->mirrorfailure_cb,
                                    "(OOO)", user_data, py_msg, py_url);
 
@@ -205,9 +206,10 @@ metadatatarget_end_callback(void *data,
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     py_msg = PyStringOrNone_FromString(msg);
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->end_cb,
                                    "(OiO)", user_data, status, py_msg);
     Py_DECREF(py_msg);

--- a/librepo/python/packagetarget-py.c
+++ b/librepo/python/packagetarget-py.c
@@ -134,9 +134,10 @@ packagetarget_end_callback(void *data,
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     py_msg = PyStringOrNone_FromString(msg);
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->end_cb,
                                    "(OiO)", user_data, status, py_msg);
     Py_DECREF(py_msg);
@@ -185,10 +186,11 @@ packagetarget_mirrorfailure_callback(void *data,
     else
         user_data = Py_None;
 
+    EndAllowThreads(self->state);
+
     py_msg = PyStringOrNone_FromString(msg);
     py_url = PyStringOrNone_FromString(url);
 
-    EndAllowThreads(self->state);
     result = PyObject_CallFunction(self->mirrorfailure_cb,
                                    "(OOO)", user_data, py_msg, py_url);
 


### PR DESCRIPTION
Librepo releases GIL for the download operations, but it wasn't taking
it again early enough in some callbacks where Python API is being called.

This commit moves taking the GIL in the callbacks to before any Python
API is called.

https://bugzilla.redhat.com/show_bug.cgi?id=1788918