### PR TITLE
Do not unref LrErr_Exception on exit (RhBug:1778854)

### DIFF
--- a/librepo/python/librepomodule.c
+++ b/librepo/python/librepomodule.c
@@ -134,7 +134,6 @@ exit_librepo(void)
 {
     Py_XDECREF(debug_cb);
     Py_XDECREF(debug_cb_data);
-    Py_XDECREF(LrErr_Exception);
 }
 
 struct module_state {


### PR DESCRIPTION
It seems the reference to a Python exception obtained from
PyErr_NewException is borrowed and is not meant to be unreferenced on
exit. From valgrind output Python frees the memory allocated for these
itself.

https://bugzilla.redhat.com/show_bug.cgi?id=1778854