### PR TITLE
lr_downloadtarget_new(): fix the file descriptor assert (RhBug:1771219)

### DIFF
--- a/librepo/downloadtarget.c
+++ b/librepo/downloadtarget.c
@@ -72,7 +72,7 @@ lr_downloadtarget_new(LrHandle *handle,
     _cleanup_free_ gchar *final_baseurl = NULL;
 
     assert(path);
-    assert((fd > 0 && !fn) || (fd < 0 && fn));
+    assert((fd >= 0 && !fn) || (fd < 0 && fn));
 
     if (byterangestart && resume) {
         g_warning("Cannot specify byterangestart and set resume to TRUE at the same time");


### PR DESCRIPTION
Include 0 for the assert on a valid fd passed for the function. Zero is
a valid value for the fd argument, the documentation does say to set fd
to -1 to "not set it" (and use the fn instead).

https://bugzilla.redhat.com/show_bug.cgi?id=1771219