### PR TITLE
[spec] Add comments after %endif to separate line

### DIFF
--- a/librepo.spec
+++ b/librepo.spec
@@ -82,7 +82,8 @@ BuildRequires:  pygpgme
 BuildRequires:  python2-pyxattr
 BuildRequires:  python2-gpg
 %endif
-%endif # with pythontests
+%endif
+# endif with pythontests
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 Conflicts:      python2-dnf < %{dnf_conflict}
 


### PR DESCRIPTION
Since rpm-4.15.0, text following %else or %endif directives produces
a warning.