### PR TITLE
Escape the package path part of the URL when downloading (RhBug:1817130)

### DIFF
--- a/librepo.spec
+++ b/librepo.spec
@@ -26,7 +26,7 @@
 %global dnf_conflict 2.8.8
 
 Name:           librepo
-Version:        1.11.3
+Version:        1.12.0
 Release:        1%{?dist}
 Summary:        Repodata downloading library
 

--- a/librepo/package_downloader.c
+++ b/librepo/package_downloader.c
@@ -255,8 +255,10 @@ lr_download_packages(GSList *targets,
         if (packagetarget->dest) {
             if (g_file_test(packagetarget->dest, G_FILE_TEST_IS_DIR)) {
                 // Dir specified
-                _cleanup_free_ gchar *file_basename;
-                file_basename = g_path_get_basename(packagetarget->relative_url);
+                // unencode first in case there are any encoded slashes to
+                // prevent any path changing shenanigans
+                _cleanup_free_ gchar * unencoded_url = g_uri_unescape_string(packagetarget->relative_url, "");
+                _cleanup_free_ gchar * file_basename = g_path_get_basename(unencoded_url);
 
                 local_path = g_build_filename(packagetarget->dest,
                                               file_basename,
@@ -266,7 +268,10 @@ lr_download_packages(GSList *targets,
             }
         } else {
             // No destination path specified
-            local_path = g_path_get_basename(packagetarget->relative_url);
+            // unencode first in case there are any encoded slashes to
+            // prevent any path changing shenanigans
+            _cleanup_free_ gchar * unencoded_url = g_uri_unescape_string(packagetarget->relative_url, "");
+            local_path = g_path_get_basename(unencoded_url);
         }
 
         packagetarget->local_path = g_string_chunk_insert(packagetarget->chunk,

--- a/librepo/package_downloader.h
+++ b/librepo/package_downloader.h
@@ -138,7 +138,8 @@ typedef struct {
  * @param relative_url      Relative part of URL to download.
  *                          First part of URL will be picked from the LrHandle
  *                          (LRO_URL or mirror) during download process or
- *                          base_url will be used if it is specified.
+ *                          base_url will be used if it is specified. It is
+ *                          expected to already come URL-encoded.
  * @param dest              Destination filename or just directory (filename
  *                          itself will be derived from the relative_url) or
  *                          NULL (current working directory + filename derived


### PR DESCRIPTION
The package name especially can contain characters that need to be
URL-encoded. However, the relative URL is a path fragment containing
slashes, which have to be left unescaped.

https://bugzilla.redhat.com/show_bug.cgi?id=1817130

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/819