### PR TITLE
librepo: Fix the key string parsing in url_substitution

### DIFF
--- a/librepo/url_substitution.c
+++ b/librepo/url_substitution.c
@@ -124,7 +124,7 @@ lr_url_substitute(const char *url, LrUrlVars *list)
                 bracket = FALSE;
             }
             const char *varname = cur;
-            for (; isalnum(*cur) || *cur == '_'; ++cur);
+            for (; isalnum(*cur) || (*cur == '_' && isalnum(*(cur + 1))); ++cur);
             if (cur != varname && (!bracket || *cur == '}')) {
                 for (LrUrlVars *elem = list; elem; elem = g_slist_next(elem)) {
                     LrVar *var_val = elem->data;


### PR DESCRIPTION
- Break the loop  if last char of key string is '_'
- Use Case:
  Lets say: releasever = 1.0
            basearch = x86_64
  URL String: $releasever_$basearch
  - Without fix:
        - parsed as $releasever_x86_64
  - With fix:
        - parsed as 1.0_x86_64

= changelog =
 msg: Fix the key string parsing in url_substitution
 type: bugfix
 resolves: string parsing issue in url_substitution

Signed-off-by: Ankit Jain <ankitja@vmware.com>