### PR TITLE
fastestmirror: Fix memory leak

### DIFF
--- a/librepo/fastestmirror.c
+++ b/librepo/fastestmirror.c
@@ -347,10 +347,6 @@ lr_fastestmirror_prepare(LrHandle *handle,
             break;
         }
 
-        LrFastestMirror *mirror = lr_lrfastestmirror_new();
-        mirror->url = url;
-        mirror->curl = curlh;
-
         curlcode = curl_easy_setopt(curlh, CURLOPT_URL, url);
         if (curlcode != CURLE_OK) {
             g_set_error(err, LR_FASTESTMIRROR_ERROR, LRE_CURL,
@@ -368,6 +364,10 @@ lr_fastestmirror_prepare(LrHandle *handle,
             ret = FALSE;
             break;
         }
+
+        LrFastestMirror *mirror = lr_lrfastestmirror_new();
+        mirror->url = url;
+        mirror->curl = curlh;
 
         list = g_slist_append(list, mirror);
     }


### PR DESCRIPTION
I ran clang's 'scan-build' on the code base and it found a potential memory leak.

If any of the two 'curl_easy_setopt' calls in the loop fails, we'll leak the recently created 'mirror' object. This object is not really needed until the moment of appending it to 'list'. This patch delays the creation of the 'mirror' object, so there won't be a code path that leaks it.