### PR TITLE
Sync data before writing checksum xattr

### DIFF
--- a/librepo/checksum.c
+++ b/librepo/checksum.c
@@ -250,6 +250,12 @@ lr_checksum_fd_compare(LrChecksumType type,
 
     *matches = (strcmp(expected, checksum)) ? FALSE : TRUE;
 
+    if (fsync(fd) != 0) {
+        g_set_error(err, LR_CHECKSUM_ERROR, LRE_FILE,
+                    "fsync failed: %s", strerror(errno));
+        return FALSE;
+    }
+
     if (caching && *matches) {
         // Store checksum as extended file attribute if caching is enabled
         struct stat st;


### PR DESCRIPTION
Writes to extended attributes are considered metadata, so can be commited to storage before data is fully synced. The upshot of this is that the checksum is cached but the file could be truncated. We attempt to sync data first to mitigate this problem.

This has been manifesting errors on real hosts with `package {p} does not verify: Payload SHA256 digest: BAD (Expected {a} != {b})` because `%_pkgverify_level` = `digest`. On inspection the files are nearly full size, the xattr is present as if the full file were there. The mtime in the xattr matches the file.