### PR TITLE
Fix default value for LRO_SSLVERIFYSTATUS

### DIFF
--- a/librepo/python/handle-py.c
+++ b/librepo/python/handle-py.c
@@ -384,8 +384,7 @@ py_setopt(_HandleObject *self, PyObject *args)
 
         // Default values for None attribute
         if (obj == Py_None && (option == LRO_SSLVERIFYPEER ||
-                               option == LRO_SSLVERIFYHOST ||
-                               option == LRO_SSLVERIFYSTATUS))
+                               option == LRO_SSLVERIFYHOST))
         {
             d = 1;
         } else if (obj == Py_None && option == LRO_ADAPTIVEMIRRORSORTING) {


### PR DESCRIPTION
When None is passed default value for LRO_SSLVERIFYSTATUS is supposed to
be 0. I made a mistake in PR https://github.com/rpm-software-management/librepo/pull/213
and the tests don't pass now.