### PR TITLE
Add support for pkcs11 certificate and key for repository authorization

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -649,6 +649,9 @@ lr_handle_setopt(LrHandle *handle,
             lr_free(handle->sslclientcert);
         handle->sslclientcert = g_strdup(va_arg(arg, char *));
         c_rc = curl_easy_setopt(c_h, CURLOPT_SSLCERT, handle->sslclientcert);
+        if (c_rc == CURLE_OK && handle->sslclientcert && !strncasecmp(handle->sslclientcert, "pkcs11:", 7)) {
+            c_rc = curl_easy_setopt(c_h, CURLOPT_SSLCERTTYPE, "ENG");
+        }
         break;
 
     case LRO_SSLCLIENTKEY:
@@ -656,6 +659,9 @@ lr_handle_setopt(LrHandle *handle,
             lr_free(handle->sslclientkey);
         handle->sslclientkey = g_strdup(va_arg(arg, char *));
         c_rc = curl_easy_setopt(c_h, CURLOPT_SSLKEY, handle->sslclientkey);
+        if (c_rc == CURLE_OK && handle->sslclientkey && !strncasecmp(handle->sslclientkey, "pkcs11:", 7)) {
+            c_rc = curl_easy_setopt(c_h, CURLOPT_SSLKEYTYPE, "ENG");
+        }
         break;
 
     case LRO_SSLCACERT:


### PR DESCRIPTION
msg: Add support for pkcs11 certificate and key for repository authorization
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1859495