### PR TITLE
LRI_SSLVERIFYSTATUS should have been added at the end of enum to preserve API

### DIFF
--- a/librepo/handle.h
+++ b/librepo/handle.h
@@ -453,7 +453,6 @@ typedef enum {
     LRI_FASTESTMIRRORMAXAGE,    /*!< (long *) */
     LRI_HMFCB,                  /*!< (LrHandleMirrorFailureCb) */
     LRI_SSLVERIFYPEER,          /*!< (long *) */
-    LRI_SSLVERIFYSTATUS,        /*!< (long *) */
     LRI_SSLVERIFYHOST,          /*!< (long *) */
     LRI_IPRESOLVE,              /*!< (LrIpResolveType *) */
     LRI_ALLOWEDMIRRORFAILURES,  /*!< (long *) */
@@ -474,6 +473,7 @@ typedef enum {
     LRI_FTPUSEEPSV,             /*!< (long) */
     LRI_YUMSLIST,               /*!< (LrUrlVars **) */
     LRI_CACHEDIR,               /*!< (char *) */
+    LRI_SSLVERIFYSTATUS,        /*!< (long *) */
     LRI_SENTINEL,
 } LrHandleInfoOption; /*!< Handle info options */
 


### PR DESCRIPTION
Introduced in https://github.com/rpm-software-management/librepo/commit/bd9f24ee0542f577057c040522249839373602ac
LRI_SSLVERIFYSTATUS should have been added at the end of the enum to
preserve API just like LRO_SSLVERIFYSTATUS was.