### PR TITLE
Fix lr_yum_download_url in case lr_handle is NULL

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -553,21 +553,23 @@ lr_yum_download_url(LrHandle *lr_handle, const char *url, int fd,
     gboolean ret;
     LrDownloadTarget *target;
     GError *tmp_err = NULL;
+    CbData *cbdata = NULL;
 
     assert(url);
     assert(!err || *err == NULL);
 
-    CbData *cbdata = cbdata_new(lr_handle->user_data,
-                                NULL,
-                                lr_handle->user_cb,
-                                lr_handle->hmfcb,
-                                url);
+    if (lr_handle != NULL)
+        cbdata = cbdata_new(lr_handle->user_data,
+                            NULL,
+                            lr_handle->user_cb,
+                            lr_handle->hmfcb,
+                            url);
 
     // Prepare target
     target = lr_downloadtarget_new(lr_handle,
                                    url, NULL, fd, NULL,
-                                   NULL, 0, 0,(lr_handle->user_cb) ? progresscb : NULL, cbdata,
-                                   NULL, (lr_handle->hmfcb) ? hmfcb : NULL, NULL, 0, 0,
+                                   NULL, 0, 0,(lr_handle && lr_handle->user_cb) ? progresscb : NULL, cbdata,
+                                   NULL, (lr_handle && lr_handle->hmfcb) ? hmfcb : NULL, NULL, 0, 0,
                                    NULL, no_cache, is_zchunk);
 
     // Download the target
@@ -575,7 +577,8 @@ lr_yum_download_url(LrHandle *lr_handle, const char *url, int fd,
 
     assert(ret || tmp_err);
     assert(!(target->err) || !ret);
-    cbdata_free(cbdata);
+    if (cbdata)
+        cbdata_free(cbdata);
 
     if (!ret)
         g_propagate_error(err, tmp_err);


### PR DESCRIPTION
This simple python reproducer made librepo dump core:

```
>>> import os, librepo, tempfile
>>> t = tempfile.TemporaryFile()
>>> librepo.download_url('file:///etc/passwd', t.fileno())
Segmentation fault (core dumped)
```