### PR TITLE
Truncate downloaded file more correctly

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1545,7 +1545,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     // Allow resume only for files that were originally being
     // downloaded by librepo
-    if (target->resume && !has_librepo_xattr(fd)) {
+    if (!(target->resume && has_librepo_xattr(fd))) {
         target->resume = FALSE;
         g_debug("%s: Resume ignored, existing file was not originally "
                 "being downloaded by Librepo", __func__);


### PR DESCRIPTION
The previous code would only truncate the file, and turn off resume if the xattr was missing. This left a gap when resume was disabled, and the xattr was missing - the file wouldn't get truncated if present.

This behaviour is strictly needed for #222 to work correctly. That does not support resuming (sorry, one day it could), so it explicitly disables resuming.