### PR TITLE
Reduce time to load metadata

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -1042,7 +1042,7 @@ lr_yum_check_checksum_of_md_record(LrYumRepoMdRecord *rec,
         zckCtx *zck = lr_zck_init_read_base(expected_checksum, checksum_type,
                                             rec->size_header, fd, &tmp_err);
         if (!tmp_err) {
-            if(zck_validate_checksums(zck) < 1) {
+            if(zck_validate_data_checksum(zck) < 1) {
                 g_set_error(&tmp_err, LR_YUM_ERROR, LRE_ZCK,
                             "Unable to validate zchunk checksums");
             } else {


### PR DESCRIPTION
See https://github.com/rpm-software-management/libdnf/issues/1216
Replace `zck_validate_checksums()` with `zck_validate_data_checksum()` to avoid to calculate `SHA512` sums in excess of `SHA256`. 
An evaluation with callgrind says that `lr_yum_perform` takes only 22% of time instead of 40% when loading metadata.