### PR TITLE
Fix link to the online documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Fedora/Ubuntu name
 
 ### Online python bindings documentation:
 
-https://rpm-software-management.github.com/librepo/
+https://rpm-software-management.github.io/librepo/
 
 ## Testing
 


### PR DESCRIPTION
Github pages are available on the github.io domain instead of github.com. That's why the link didn't work. This patch fixes the link.