### PR TITLE
Recover from fsync fail on read-only filesystem (RhBug:1956361)

### DIFF
--- a/librepo/checksum.c
+++ b/librepo/checksum.c
@@ -266,9 +266,13 @@ lr_checksum_fd_compare(LrChecksumType type,
     *matches = (strcmp(expected, checksum)) ? FALSE : TRUE;
 
     if (fsync(fd) != 0) {
-        g_set_error(err, LR_CHECKSUM_ERROR, LRE_FILE,
-                    "fsync failed: %s", strerror(errno));
-        return FALSE;
+        if (errno == EROFS || errno == EINVAL) {
+            g_debug("fsync failed: %s", strerror(errno));
+        } else {
+            g_set_error(err, LR_CHECKSUM_ERROR, LRE_FILE,
+                        "fsync failed: %s", strerror(errno));
+            return FALSE;
+        }
     }
 
     if (caching && *matches && timestamp != -1) {


### PR DESCRIPTION
When `fsync` fails due to the file not supporting synchronization just log
the problem instead of failing the whole dnf run. This happens for
example with filesystems mounted read-only in which case there is no
point to `fsync` anyway.

Currently we also ignore return values from `FSETXATTR` which also fails
on read-only filesystem (so no checksum cache is set). This is fine however
since the checksum is recomputed when needed, dnf is just a bit slower.

https://bugzilla.redhat.com/show_bug.cgi?id=1956361

@malmond77 can you take a look at this please?