### PR TITLE
`fail_if` and `fail_unless` are deprecated

### DIFF
--- a/tests/test_downloader.c
+++ b/tests/test_downloader.c
@@ -20,18 +20,14 @@
 
 START_TEST(test_downloader_no_list)
 {
-    int ret;
     GError *err = NULL;
-
-    ret = lr_download(NULL, FALSE, &err);
-    fail_if(!ret);
-    fail_if(err);
+    ck_assert(lr_download(NULL, FALSE, &err));
+    ck_assert_ptr_null(err);
 }
 END_TEST
 
 START_TEST(test_downloader_single_file)
 {
-    int ret;
     LrHandle *handle;
     GSList *list = NULL;
     GError *err = NULL;
@@ -43,12 +39,12 @@ START_TEST(test_downloader_single_file)
     // Prepare handle
 
     handle = lr_handle_init();
-    fail_if(handle == NULL);
+    ck_assert_ptr_nonnull(handle);
 
     char *urls[] = {"http://www.google.com", NULL};
-    fail_if(!lr_handle_setopt(handle, NULL, LRO_URLS, urls));
+    ck_assert(lr_handle_setopt(handle, NULL, LRO_URLS, urls));
     lr_handle_prepare_internal_mirrorlist(handle, FALSE, &tmp_err);
-    fail_if(tmp_err);
+    ck_assert_ptr_null(tmp_err);
 
 
     // Prepare list of download targets
@@ -57,20 +53,19 @@ START_TEST(test_downloader_single_file)
 
     fd1 = mkstemp(tmpfn1);
     lr_free(tmpfn1);
-    fail_if(fd1 < 0);
+    ck_assert_int_ge(fd1, 0);
 
     t1 = lr_downloadtarget_new(handle, "index.html", NULL, fd1, NULL, NULL,
                                0, 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL,
                                FALSE, FALSE);
-    fail_if(!t1);
+    ck_assert_ptr_nonnull(t1);
 
     list = g_slist_append(list, t1);
 
     // Download
 
-    ret = lr_download(list, FALSE, &err);
-    fail_if(!ret);
-    fail_if(err);
+    ck_assert(lr_download(list, FALSE, &err));
+    ck_assert_ptr_null(err);
 
     lr_handle_free(handle);
 
@@ -91,7 +86,6 @@ END_TEST
 
 START_TEST(test_downloader_single_file_2)
 {
-    int ret;
     GSList *list = NULL;
     GError *err = NULL;
     int fd1;
@@ -104,20 +98,19 @@ START_TEST(test_downloader_single_file_2)
 
     fd1 = mkstemp(tmpfn1);
     lr_free(tmpfn1);
-    fail_if(fd1 < 0);
+    ck_assert_int_ge(fd1, 0);
 
     t1 = lr_downloadtarget_new(NULL, "http://seznam.cz/index.html", NULL,
                                fd1, NULL, NULL, 0, 0, NULL, NULL, NULL,
                                NULL, NULL, 0, 0, NULL, FALSE, FALSE);
-    fail_if(!t1);
+    ck_assert_ptr_nonnull(t1);
 
     list = g_slist_append(list, t1);
 
     // Download
 
-    ret = lr_download(list, FALSE, &err);
-    fail_if(!ret);
-    fail_if(err);
+    ck_assert(lr_download(list, FALSE, &err));
+    ck_assert_ptr_null(err);
 
     // Check results
 
@@ -136,7 +129,6 @@ END_TEST
 
 START_TEST(test_downloader_two_files)
 {
-    int ret;
     LrHandle *handle;
     GSList *list = NULL;
     GError *err = NULL;
@@ -148,12 +140,12 @@ START_TEST(test_downloader_two_files)
     // Prepare handle
 
     handle = lr_handle_init();
-    fail_if(handle == NULL);
+    ck_assert_ptr_nonnull(handle);
 
     char *urls[] = {"http://www.google.com", NULL};
-    fail_if(!lr_handle_setopt(handle, NULL, LRO_URLS, urls));
+    ck_assert(lr_handle_setopt(handle, NULL, LRO_URLS, urls));
     lr_handle_prepare_internal_mirrorlist(handle, FALSE, &tmp_err);
-    fail_if(tmp_err);
+    ck_assert_ptr_null(tmp_err);
 
     // Prepare list of download targets
 
@@ -164,26 +156,25 @@ START_TEST(test_downloader_two_files)
     fd2 = mkstemp(tmpfn2);
     lr_free(tmpfn1);
     lr_free(tmpfn2);
-    fail_if(fd1 < 0);
-    fail_if(fd2 < 0);
+    ck_assert_int_ge(fd1, 0);
+    ck_assert_int_ge(fd2, 0);
 
     t1 = lr_downloadtarget_new(handle, "index.html", NULL, fd1, NULL,
                                NULL, 0, 0, NULL, NULL, NULL,
                                NULL, NULL, 0, 0, NULL, FALSE, FALSE);
-    fail_if(!t1);
+    ck_assert_ptr_nonnull(t1);
     t2 = lr_downloadtarget_new(handle, "index.html", "http://seznam.cz", fd2,
                                NULL, NULL, 0, 0, NULL, NULL, NULL,
                                NULL, NULL, 0, 0, NULL, FALSE, FALSE);
-    fail_if(!t2);
+    ck_assert_ptr_nonnull(t2);
 
     list = g_slist_append(list, t1);
     list = g_slist_append(list, t2);
 
     // Download
 
-    ret = lr_download(list, FALSE, &err);
-    fail_if(!ret);
-    fail_if(err);
+    ck_assert(lr_download(list, FALSE, &err));
+    ck_assert_ptr_null(err);
 
     lr_handle_free(handle);
 
@@ -205,7 +196,6 @@ END_TEST
 
 START_TEST(test_downloader_three_files_with_error)
 {
-    int ret;
     LrHandle *handle;
     GSList *list = NULL;
     GError *err = NULL;
@@ -217,12 +207,12 @@ START_TEST(test_downloader_three_files_with_error)
     // Prepare handle
 
     handle = lr_handle_init();
-    fail_if(handle == NULL);
+    ck_assert_ptr_nonnull(handle);
 
     char *urls[] = {"http://www.google.com", NULL};
-    fail_if(!lr_handle_setopt(handle, NULL, LRO_URLS, urls));
+    ck_assert(lr_handle_setopt(handle, NULL, LRO_URLS, urls));
     lr_handle_prepare_internal_mirrorlist(handle, FALSE, &tmp_err);
-    fail_if(tmp_err);
+    ck_assert_ptr_null(tmp_err);
 
     // Prepare list of download targets
 
@@ -236,25 +226,25 @@ START_TEST(test_downloader_three_files_with_error)
     lr_free(tmpfn1);
     lr_free(tmpfn2);
     lr_free(tmpfn3);
-    fail_if(fd1 < 0);
-    fail_if(fd2 < 0);
-    fail_if(fd3 < 0);
+    ck_assert_int_ge(fd1, 0);
+    ck_assert_int_ge(fd2, 0);
+    ck_assert_int_ge(fd3, 0);
 
     t1 = lr_downloadtarget_new(handle, "index.html", NULL, fd1, NULL, NULL,
                                0, 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL,
                                FALSE, FALSE);
-    fail_if(!t1);
+    ck_assert_ptr_nonnull(t1);
 
     t2 = lr_downloadtarget_new(handle, "index.html", "http://seznam.cz", fd2,
                                NULL, NULL, 0, 0, NULL, NULL, NULL, NULL,
                                NULL, 0, 0, NULL, FALSE, FALSE);
-    fail_if(!t2);
+    ck_assert_ptr_nonnull(t2);
 
     t3 = lr_downloadtarget_new(handle, "i_hope_this_page_doesnt_exists.html",
                                "http://google.com", fd3, NULL, NULL,
                                0, 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL,
                                FALSE, FALSE);
-    fail_if(!t3);
+    ck_assert_ptr_nonnull(t3);
 
     list = g_slist_append(list, t1);
     list = g_slist_append(list, t2);
@@ -262,9 +252,8 @@ START_TEST(test_downloader_three_files_with_error)
 
     // Download
 
-    ret = lr_download(list, FALSE, &err);
-    fail_if(!ret);
-    fail_if(err);
+    ck_assert(lr_download(list, FALSE, &err));
+    ck_assert_ptr_null(err);
 
     lr_handle_free(handle);
 
@@ -314,7 +303,6 @@ START_TEST(test_downloader_checksum)
     int i;
 
     for (i = 0; tests[i].sha512; i++) {
-        int ret;
         LrHandle *handle;
         GSList *list = NULL;
         GError *err = NULL;
@@ -328,12 +316,12 @@ START_TEST(test_downloader_checksum)
         // Prepare handle
 
         handle = lr_handle_init();
-        fail_if(handle == NULL);
+        ck_assert_ptr_nonnull(handle);
 
         char *urls[] = {"file:///", NULL};
-        fail_if(!lr_handle_setopt(handle, NULL, LRO_URLS, urls));
+        ck_assert(lr_handle_setopt(handle, NULL, LRO_URLS, urls));
         lr_handle_prepare_internal_mirrorlist(handle, FALSE, &tmp_err);
-        fail_if(tmp_err);
+        ck_assert_ptr_null(tmp_err);
 
 
         // Prepare list of download targets
@@ -342,7 +330,7 @@ START_TEST(test_downloader_checksum)
 
         fd1 = mkstemp(tmpfn1);
         lr_free(tmpfn1);
-        fail_if(fd1 < 0);
+        ck_assert_int_ge(fd1, 0);
 
         checksum = lr_downloadtargetchecksum_new(LR_CHECKSUM_SHA512,
                                                  tests[i].sha512);
@@ -351,15 +339,14 @@ START_TEST(test_downloader_checksum)
         t1 = lr_downloadtarget_new(handle, "dev/null", NULL, fd1, NULL, checksums,
                                    0, 0, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL,
                                    FALSE, FALSE);
-        fail_if(!t1);
+        ck_assert_ptr_nonnull(t1);
 
         list = g_slist_append(list, t1);
 
         // Download
 
-        ret = lr_download(list, FALSE, &err);
-        fail_if(!ret);
-        fail_if(err);
+        ck_assert(lr_download(list, FALSE, &err));
+        ck_assert_ptr_null(err);
 
         lr_handle_free(handle);
 

--- a/tests/test_gpg.c
+++ b/tests/test_gpg.c
@@ -39,24 +39,24 @@ START_TEST(test_gpg_check_signature)
                              "repo_yum_01/repodata/repomd.xml_bad.asc", NULL);
 
     ret = lr_gpg_import_key(key_path, tmp_home_path, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
 
     // Valid key and data
     ret = lr_gpg_check_signature(signature_path,
                                  data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
 
     // Bad signature signed with unknown key
     ret = lr_gpg_check_signature(_signature_path,
                                  data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     tmp_err = NULL;
 
@@ -65,31 +65,31 @@ START_TEST(test_gpg_check_signature)
                                  _data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     tmp_err = NULL;
 
     // Import the 2nd key
     ret = lr_gpg_import_key(_key_path, tmp_home_path, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
 
     // Valid key and data
     ret = lr_gpg_check_signature(_signature_path,
                                  _data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
 
     // Bad signature signed with known key
     ret = lr_gpg_check_signature(_signature_path,
                                  data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     tmp_err = NULL;
 
@@ -98,8 +98,8 @@ START_TEST(test_gpg_check_signature)
                                  data_path,
                                  tmp_home_path,
                                  &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     tmp_err = NULL;
 

--- a/tests/test_handle.c
+++ b/tests/test_handle.c
@@ -22,42 +22,42 @@ START_TEST(test_handle)
     GError *tmp_err = NULL;
 
     h = lr_handle_init();
-    fail_if(h == NULL);
+    ck_assert_ptr_nonnull(h);
     lr_handle_free(h);
     h = NULL;
 
     /* This test is meant to check memory leaks. (Use valgrind) */
     h = lr_handle_init();
     char *urls[] = {"foo", NULL};
-    fail_if(!lr_handle_setopt(h, &tmp_err, LRO_URLS, urls));
-    fail_if(tmp_err);
-    fail_if(!lr_handle_setopt(h, &tmp_err, LRO_URLS, urls));
-    fail_if(tmp_err);
-    fail_if(!lr_handle_setopt(h, &tmp_err, LRO_MIRRORLIST, "foo"));
-    fail_if(tmp_err);
-    fail_if(!lr_handle_setopt(h, &tmp_err, LRO_MIRRORLIST, "bar"));
-    fail_if(tmp_err);
-    fail_if(!lr_handle_setopt(h, NULL, LRO_USERPWD, "user:pwd"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXY, "proxy"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXYUSERPWD, "proxyuser:pwd"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_DESTDIR, "foodir"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_USERAGENT, "librepo/0.0"));
+    ck_assert(lr_handle_setopt(h, &tmp_err, LRO_URLS, urls));
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(lr_handle_setopt(h, &tmp_err, LRO_URLS, urls));
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(lr_handle_setopt(h, &tmp_err, LRO_MIRRORLIST, "foo"));
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(lr_handle_setopt(h, &tmp_err, LRO_MIRRORLIST, "bar"));
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(lr_handle_setopt(h, NULL, LRO_USERPWD, "user:pwd"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY, "proxy"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXYUSERPWD, "proxyuser:pwd"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_DESTDIR, "foodir"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_USERAGENT, "librepo/0.0"));
     char *dlist[] = {"primary", "filelists", NULL};
-    fail_if(!lr_handle_setopt(h, NULL, LRO_YUMDLIST, dlist));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_YUMBLIST, dlist));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_YUMDLIST, dlist));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_YUMBLIST, dlist));
     LrUrlVars *vars = NULL;
     vars = lr_urlvars_set(vars, "foo", "bar");
-    fail_if(!lr_handle_setopt(h, NULL, LRO_VARSUB, vars));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_FASTESTMIRRORCACHE,
+    ck_assert(lr_handle_setopt(h, NULL, LRO_VARSUB, vars));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_FASTESTMIRRORCACHE,
                               "/var/cache/fastestmirror.librepo"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_SSLCLIENTCERT, "/etc/cert.pem"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_SSLCLIENTKEY, "/etc/cert.key"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_SSLCACERT, "/etc/ca.pem"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTCERT, "/etc/proxy_cert.pem"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTKEY, "/etc/proxy_cert.key"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXY_SSLCACERT, "/etc/proxy_ca.pem"));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_HTTPAUTHMETHODS, LR_AUTH_NTLM));
-    fail_if(!lr_handle_setopt(h, NULL, LRO_PROXYAUTHMETHODS, LR_AUTH_DIGEST));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_SSLCLIENTCERT, "/etc/cert.pem"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_SSLCLIENTKEY, "/etc/cert.key"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_SSLCACERT, "/etc/ca.pem"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTCERT, "/etc/proxy_cert.pem"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTKEY, "/etc/proxy_cert.key"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCACERT, "/etc/proxy_ca.pem"));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_HTTPAUTHMETHODS, LR_AUTH_NTLM));
+    ck_assert(lr_handle_setopt(h, NULL, LRO_PROXYAUTHMETHODS, LR_AUTH_DIGEST));
     lr_handle_free(h);
 }
 END_TEST
@@ -73,90 +73,90 @@ START_TEST(test_handle_getinfo)
     h = lr_handle_init();
 
     num = -1;
-    fail_if(!lr_handle_getinfo(h, &tmp_err, LRI_UPDATE, &num));
-    fail_if(num != 0);
-    fail_if(tmp_err);
+    ck_assert(lr_handle_getinfo(h, &tmp_err, LRI_UPDATE, &num));
+    ck_assert(num == 0);
+    ck_assert_ptr_null(tmp_err);
 
     strlist = NULL;
-    fail_if(!lr_handle_getinfo(h, &tmp_err, LRI_URLS, &strlist));
-    fail_if(strlist != NULL);
-    fail_if(tmp_err);
+    ck_assert(lr_handle_getinfo(h, &tmp_err, LRI_URLS, &strlist));
+    ck_assert_ptr_null(strlist);
+    ck_assert_ptr_null(tmp_err);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_MIRRORLIST, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_MIRRORLIST, &str));
+    ck_assert_ptr_null(str);
 
     num = -1;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_LOCAL, &num));
-    fail_if(num != 0);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_LOCAL, &num));
+    ck_assert(num == 0);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_DESTDIR, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_DESTDIR, &str));
+    ck_assert_ptr_null(str);
 
     num = -1;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_REPOTYPE, &num));
-    fail_if(num != 0);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_REPOTYPE, &num));
+    ck_assert(num == 0);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_USERAGENT, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_USERAGENT, &str));
+    ck_assert_ptr_null(str);
 
     strlist = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_YUMDLIST, &strlist));
-    fail_if(strlist != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_YUMDLIST, &strlist));
+    ck_assert_ptr_null(strlist);
 
     strlist = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_YUMBLIST, &strlist));
-    fail_if(strlist != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_YUMBLIST, &strlist));
+    ck_assert_ptr_null(strlist);
 
     num = -1;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_MAXMIRRORTRIES, &num));
-    fail_if(num != 0);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_MAXMIRRORTRIES, &num));
+    ck_assert(num == 0);
 
     LrUrlVars *vars = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_VARSUB, &vars));
-    fail_if(strlist != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_VARSUB, &vars));
+    ck_assert_ptr_null(strlist);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_FASTESTMIRRORCACHE, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_FASTESTMIRRORCACHE, &str));
+    ck_assert_ptr_null(str);
 
     num = -1;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_FASTESTMIRRORMAXAGE, &num));
-    fail_if(num != LRO_FASTESTMIRRORMAXAGE_DEFAULT);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_FASTESTMIRRORMAXAGE, &num));
+    ck_assert(num == LRO_FASTESTMIRRORMAXAGE_DEFAULT);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_SSLCLIENTCERT, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_SSLCLIENTCERT, &str));
+    ck_assert_ptr_null(str);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_SSLCLIENTKEY, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_SSLCLIENTKEY, &str));
+    ck_assert_ptr_null(str);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_SSLCACERT, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_SSLCACERT, &str));
+    ck_assert_ptr_null(str);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCLIENTCERT, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCLIENTCERT, &str));
+    ck_assert_ptr_null(str);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCLIENTKEY, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCLIENTKEY, &str));
+    ck_assert_ptr_null(str);
 
     str = NULL;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCACERT, &str));
-    fail_if(str != NULL);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_PROXY_SSLCACERT, &str));
+    ck_assert_ptr_null(str);
 
     LrAuth auth = LR_AUTH_NONE;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_HTTPAUTHMETHODS, &auth));
-    fail_if(auth != LR_AUTH_BASIC);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_HTTPAUTHMETHODS, &auth));
+    ck_assert(auth == LR_AUTH_BASIC);
 
     auth = LR_AUTH_NONE;
-    fail_if(!lr_handle_getinfo(h, NULL, LRI_PROXYAUTHMETHODS, &auth));
-    fail_if(auth != LR_AUTH_BASIC);
+    ck_assert(lr_handle_getinfo(h, NULL, LRI_PROXYAUTHMETHODS, &auth));
+    ck_assert(auth == LR_AUTH_BASIC);
 
     lr_handle_free(h);
 }

--- a/tests/test_lrmirrorlist.c
+++ b/tests/test_lrmirrorlist.c
@@ -29,16 +29,16 @@ START_TEST(test_lrmirrorlist_append_url)
     lr_urlvars_free(vars);
 
     mirror = lr_lrmirrorlist_nth(iml, 0);
-    fail_if(!mirror);
-    fail_if(strcmp(mirror->url, "ftp://bar"));
+    ck_assert_ptr_nonnull(mirror);
+    ck_assert_str_eq(mirror->url, "ftp://bar");
 
     mirror = lr_lrmirrorlist_nth(iml, 1);
-    fail_if(!mirror);
-    fail_if(strcmp(mirror->url, "http://foo"));
+    ck_assert_ptr_nonnull(mirror);
+    ck_assert_str_eq(mirror->url, "http://foo");
 
     mirror = lr_lrmirrorlist_nth(iml, 2);
-    fail_if(!mirror);
-    fail_if(strcmp(mirror->url, "http://xyz/i386/"));
+    ck_assert_ptr_nonnull(mirror);
+    ck_assert_str_eq(mirror->url, "http://xyz/i386/");
 
     lr_lrmirrorlist_free(iml);
 }
@@ -56,30 +56,30 @@ START_TEST(test_lrmirrorlist_append_mirrorlist)
     ml.urls = g_slist_prepend(ml.urls, "ftp://bar");
     ml.urls = g_slist_prepend(ml.urls, "http://foo");
 
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
     iml = lr_lrmirrorlist_append_mirrorlist(iml, NULL, NULL);
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
 
     iml = lr_lrmirrorlist_append_mirrorlist(iml, &ml, NULL);
-    fail_if(g_slist_length(iml) != 2);
+    ck_assert(g_slist_length(iml) == 2);
     mirror = lr_lrmirrorlist_nth(iml, 0);
-    fail_if(!mirror);
-    fail_if(strcmp(mirror->url, "http://foo"));
-    fail_if(mirror->preference != 100);
-    fail_if(mirror->protocol != LR_PROTOCOL_HTTP);
+    ck_assert_ptr_nonnull(mirror);
+    ck_assert_str_eq(mirror->url, "http://foo");
+    ck_assert(mirror->preference == 100);
+    ck_assert(mirror->protocol == LR_PROTOCOL_HTTP);
     mirror = lr_lrmirrorlist_nth(iml, 1);
-    fail_if(!mirror);
-    fail_if(strcmp(mirror->url, "ftp://bar"));
-    fail_if(mirror->preference != 100);
-    fail_if(mirror->protocol != LR_PROTOCOL_FTP);
+    ck_assert_ptr_nonnull(mirror);
+    ck_assert_str_eq(mirror->url, "ftp://bar");
+    ck_assert(mirror->preference == 100);
+    ck_assert(mirror->protocol == LR_PROTOCOL_FTP);
 
-    fail_if(g_slist_length(iml) != 2);
+    ck_assert(g_slist_length(iml) == 2);
 
     url = lr_lrmirrorlist_nth_url(iml, 0);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
 
     url = lr_lrmirrorlist_nth_url(iml, 1);
-    fail_if(strcmp(url, "ftp://bar"));
+    ck_assert_str_eq(url, "ftp://bar");
 
     lr_lrmirrorlist_free(iml);
     g_slist_free(ml.urls);
@@ -132,46 +132,46 @@ START_TEST(test_lrmirrorlist_append_metalink)
     ml.urls = g_slist_prepend(ml.urls, &url2);
     ml.urls = g_slist_prepend(ml.urls, &url1);
 
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
     iml = lr_lrmirrorlist_append_metalink(iml, NULL, NULL, NULL);
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
 
     iml = lr_lrmirrorlist_append_metalink(iml, &ml, "/repodata/repomd.xml", NULL);
-    fail_if(g_slist_length(iml) != 2);  // 2 because element with empty url shoud be skipped
+    ck_assert(g_slist_length(iml) == 2);  // 2 because element with empty url shoud be skipped
 
     mirror = lr_lrmirrorlist_nth(iml, 0);
-    fail_if(strcmp(mirror->url, "http://foo"));
-    fail_if(mirror->preference != 100);
-    fail_if(mirror->protocol != LR_PROTOCOL_HTTP);
+    ck_assert_str_eq(mirror->url, "http://foo");
+    ck_assert(mirror->preference == 100);
+    ck_assert(mirror->protocol == LR_PROTOCOL_HTTP);
 
     mirror = lr_lrmirrorlist_nth(iml, 1);
-    fail_if(strcmp(mirror->url, "ftp://bar"));
-    fail_if(mirror->preference != 95);
-    fail_if(mirror->protocol != LR_PROTOCOL_FTP);
+    ck_assert_str_eq(mirror->url, "ftp://bar");
+    ck_assert(mirror->preference == 95);
+    ck_assert(mirror->protocol == LR_PROTOCOL_FTP);
 
-    fail_if(g_slist_length(iml) != 2);
+    ck_assert(g_slist_length(iml) == 2);
 
     url = lr_lrmirrorlist_nth_url(iml, 0);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
 
     url = lr_lrmirrorlist_nth_url(iml, 1);
-    fail_if(strcmp(url, "ftp://bar"));
+    ck_assert_str_eq(url, "ftp://bar");
 
     lr_lrmirrorlist_free(iml);
 
     // Try append on list with existing element
     iml = NULL;
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
     iml = lr_lrmirrorlist_append_url(iml, "http://abc", NULL);
-    fail_if(g_slist_length(iml) != 1);
+    ck_assert(g_slist_length(iml) == 1);
     iml = lr_lrmirrorlist_append_metalink(iml, &ml, "/repodata/repomd.xml", NULL);
-    fail_if(g_slist_length(iml) != 3);
+    ck_assert(g_slist_length(iml) == 3);
     url = lr_lrmirrorlist_nth_url(iml, 0);
-    fail_if(strcmp(url, "http://abc"));
+    ck_assert_str_eq(url, "http://abc");
     url = lr_lrmirrorlist_nth_url(iml, 1);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
     url = lr_lrmirrorlist_nth_url(iml, 2);
-    fail_if(strcmp(url, "ftp://bar"));
+    ck_assert_str_eq(url, "ftp://bar");
 
     lr_lrmirrorlist_free(iml);
     g_slist_free(ml.urls);
@@ -189,48 +189,48 @@ START_TEST(test_lrmirrorlist_append_lrmirrorlist)
     iml_2 = lr_lrmirrorlist_append_url(iml_2, NULL, NULL);
     iml_2 = lr_lrmirrorlist_append_url(iml_2, "ftp://bar", NULL);
 
-    fail_if(g_slist_length(iml_2) != 2);
+    ck_assert(g_slist_length(iml_2) == 2);
 
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
     iml = lr_lrmirrorlist_append_lrmirrorlist(iml, NULL);
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
 
     iml = lr_lrmirrorlist_append_lrmirrorlist(iml, iml_2);
-    fail_if(g_slist_length(iml) != 2);  // 2 because element with empty url shoud be skipped
+    ck_assert(g_slist_length(iml) == 2);  // 2 because element with empty url shoud be skipped
 
     mirror = lr_lrmirrorlist_nth(iml, 0);
-    fail_if(strcmp(mirror->url, "http://foo"));
-    fail_if(mirror->preference != 100);
-    fail_if(mirror->protocol != LR_PROTOCOL_HTTP);
+    ck_assert_str_eq(mirror->url, "http://foo");
+    ck_assert(mirror->preference == 100);
+    ck_assert(mirror->protocol == LR_PROTOCOL_HTTP);
 
     mirror = lr_lrmirrorlist_nth(iml, 1);
-    fail_if(strcmp(mirror->url, "ftp://bar"));
-    fail_if(mirror->preference != 100);
-    fail_if(mirror->protocol != LR_PROTOCOL_FTP);
+    ck_assert_str_eq(mirror->url, "ftp://bar");
+    ck_assert(mirror->preference == 100);
+    ck_assert(mirror->protocol == LR_PROTOCOL_FTP);
 
-    fail_if(g_slist_length(iml) != 2);
+    ck_assert(g_slist_length(iml) == 2);
 
     url = lr_lrmirrorlist_nth_url(iml, 0);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
 
     url = lr_lrmirrorlist_nth_url(iml, 1);
-    fail_if(strcmp(url, "ftp://bar"));
+    ck_assert_str_eq(url, "ftp://bar");
 
     lr_lrmirrorlist_free(iml);
 
     // Try append on list with existing element
     iml = NULL;
-    fail_if(g_slist_length(iml) != 0);
+    ck_assert(g_slist_length(iml) == 0);
     iml = lr_lrmirrorlist_append_url(iml, "http://abc", NULL);
-    fail_if(g_slist_length(iml) != 1);
+    ck_assert(g_slist_length(iml) == 1);
     iml = lr_lrmirrorlist_append_lrmirrorlist(iml, iml_2);
-    fail_if(g_slist_length(iml) != 3);
+    ck_assert(g_slist_length(iml) == 3);
     url = lr_lrmirrorlist_nth_url(iml, 0);
-    fail_if(strcmp(url, "http://abc"));
+    ck_assert_str_eq(url, "http://abc");
     url = lr_lrmirrorlist_nth_url(iml, 1);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
     url = lr_lrmirrorlist_nth_url(iml, 2);
-    fail_if(strcmp(url, "ftp://bar"));
+    ck_assert_str_eq(url, "ftp://bar");
     lr_lrmirrorlist_free(iml);
     lr_lrmirrorlist_free(iml_2);
 }

--- a/tests/test_metalink.c
+++ b/tests/test_metalink.c
@@ -29,7 +29,7 @@ START_TEST(test_metalink_init)
     LrMetalink *ml = NULL;
 
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     lr_metalink_free(ml);
 }
 END_TEST
@@ -49,101 +49,101 @@ START_TEST(test_metalink_good_01)
                          "metalink_good_01", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
     close(fd);
 
-    fail_if(ml->filename == NULL);
-    fail_if(strcmp(ml->filename, "repomd.xml"));
-    fail_if(ml->timestamp != 1337942396);
-    fail_if(ml->size != 4309);
-    fail_if(g_slist_length(ml->hashes) != 4);
-    fail_if(g_slist_length(ml->urls) != 106);
+    ck_assert_ptr_nonnull(ml->filename);
+    ck_assert_str_eq(ml->filename, "repomd.xml");
+    ck_assert(ml->timestamp == 1337942396);
+    ck_assert(ml->size == 4309);
+    ck_assert(g_slist_length(ml->hashes) == 4);
+    ck_assert(g_slist_length(ml->urls) == 106);
 
     elem = g_slist_nth(ml->hashes, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "md5"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "20b6d77930574ae541108e8e7987ad3f"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "md5");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "20b6d77930574ae541108e8e7987ad3f");
 
     elem = g_slist_nth(ml->hashes, 1);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "sha1"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "4a5ae1831a567b58e2e0f0de1529ca199d1d8319"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "sha1");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "4a5ae1831a567b58e2e0f0de1529ca199d1d8319");
 
     elem = g_slist_nth(ml->hashes, 2);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "sha256"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "0076c44aabd352da878d5c4d794901ac87f66afac869488f6a4ef166de018cdf"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "sha256");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "0076c44aabd352da878d5c4d794901ac87f66afac869488f6a4ef166de018cdf");
 
     elem = g_slist_nth(ml->hashes, 3);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "sha512"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "884dc465da67fee8fe3f11dab321a99d9a13b22ce97f84ceff210e82b6b1a8c635ccd196add1dd738807686714c3a0a048897e2d0650bc05302b3ee26de521fd"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "sha512");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "884dc465da67fee8fe3f11dab321a99d9a13b22ce97f84ceff210e82b6b1a8c635ccd196add1dd738807686714c3a0a048897e2d0650bc05302b3ee26de521fd");
 
     elem = g_slist_nth(ml->urls, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol == NULL);
-    fail_if(strcmp(mlurl->protocol, "http"));
-    fail_if(mlurl->type == NULL);
-    fail_if(strcmp(mlurl->type, "http"));
-    fail_if(mlurl->location == NULL);
-    fail_if(strcmp(mlurl->location, "US"));
-    fail_if(mlurl->preference != 99);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_nonnull(mlurl->protocol);
+    ck_assert_str_eq(mlurl->protocol, "http");
+    ck_assert_ptr_nonnull(mlurl->type);
+    ck_assert_str_eq(mlurl->type, "http");
+    ck_assert_ptr_nonnull(mlurl->location);
+    ck_assert_str_eq(mlurl->location, "US");
+    ck_assert(mlurl->preference == 99);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     elem = g_slist_nth(ml->urls, 2);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol == NULL);
-    fail_if(strcmp(mlurl->protocol, "ftp"));
-    fail_if(mlurl->type == NULL);
-    fail_if(strcmp(mlurl->type, "ftp"));
-    fail_if(mlurl->location == NULL);
-    fail_if(strcmp(mlurl->location, "US"));
-    fail_if(mlurl->preference != 98);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "ftp://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_nonnull(mlurl->protocol);
+    ck_assert_str_eq(mlurl->protocol, "ftp");
+    ck_assert_ptr_nonnull(mlurl->type);
+    ck_assert_str_eq(mlurl->type, "ftp");
+    ck_assert_ptr_nonnull(mlurl->location);
+    ck_assert_str_eq(mlurl->location, "US");
+    ck_assert(mlurl->preference == 98);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "ftp://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     elem = g_slist_nth(ml->urls, 104);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol == NULL);
-    fail_if(strcmp(mlurl->protocol, "rsync"));
-    fail_if(mlurl->type == NULL);
-    fail_if(strcmp(mlurl->type, "rsync"));
-    fail_if(mlurl->location == NULL);
-    fail_if(strcmp(mlurl->location, "CA"));
-    fail_if(mlurl->preference != 48);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "rsync://mirror.csclub.uwaterloo.ca/fedora-enchilada/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_nonnull(mlurl->protocol);
+    ck_assert_str_eq(mlurl->protocol, "rsync");
+    ck_assert_ptr_nonnull(mlurl->type);
+    ck_assert_str_eq(mlurl->type, "rsync");
+    ck_assert_ptr_nonnull(mlurl->location);
+    ck_assert_str_eq(mlurl->location, "CA");
+    ck_assert(mlurl->preference == 48);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "rsync://mirror.csclub.uwaterloo.ca/fedora-enchilada/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     lr_metalink_free(ml);
 }
@@ -161,35 +161,35 @@ START_TEST(test_metalink_good_02)
                          "metalink_good_02", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
     close(fd);
 
-    fail_if(ml->filename == NULL);
-    fail_if(strcmp(ml->filename, "repomd.xml"));
-    fail_if(ml->timestamp != 0);
-    fail_if(ml->size != 0);
-    fail_if(g_slist_length(ml->hashes) != 0);
-    fail_if(g_slist_length(ml->urls) != 3);
+    ck_assert_ptr_nonnull(ml->filename);
+    ck_assert_str_eq(ml->filename, "repomd.xml");
+    ck_assert(ml->timestamp == 0);
+    ck_assert(ml->size == 0);
+    ck_assert(g_slist_length(ml->hashes) == 0);
+    ck_assert(g_slist_length(ml->urls) == 3);
 
     GSList *list = g_slist_nth(ml->urls, 0);
-    fail_if(!list);
+    ck_assert_ptr_nonnull(list);
     LrMetalinkUrl *mlurl = list->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol == NULL);
-    fail_if(strcmp(mlurl->protocol, "http"));
-    fail_if(mlurl->type == NULL);
-    fail_if(strcmp(mlurl->type, "http"));
-    fail_if(mlurl->location == NULL);
-    fail_if(strcmp(mlurl->location, "US"));
-    fail_if(mlurl->preference != 97);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_nonnull(mlurl->protocol);
+    ck_assert_str_eq(mlurl->protocol, "http");
+    ck_assert_ptr_nonnull(mlurl->type);
+    ck_assert_str_eq(mlurl->type, "http");
+    ck_assert_ptr_nonnull(mlurl->location);
+    ck_assert_str_eq(mlurl->location, "US");
+    ck_assert(mlurl->preference == 97);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     lr_metalink_free(ml);
 }
@@ -207,20 +207,20 @@ START_TEST(test_metalink_good_03)
                          "metalink_good_03", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
     close(fd);
 
-    fail_if(ml->filename == NULL);
-    fail_if(strcmp(ml->filename, "repomd.xml"));
-    fail_if(ml->timestamp != 0);
-    fail_if(ml->size != 0);
-    fail_if(g_slist_length(ml->hashes) != 0);
-    fail_if(g_slist_length(ml->urls) != 0);
+    ck_assert_ptr_nonnull(ml->filename);
+    ck_assert_str_eq(ml->filename, "repomd.xml");
+    ck_assert(ml->timestamp == 0);
+    ck_assert(ml->size == 0);
+    ck_assert(g_slist_length(ml->hashes) == 0);
+    ck_assert(g_slist_length(ml->urls) == 0);
 
     lr_metalink_free(ml);
 }
@@ -251,112 +251,110 @@ START_TEST(test_metalink_bad_01)
                          "metalink_bad_01", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     int call_counter = 0;
     ret = lr_metalink_parse_file(ml, fd, REPOMD, warning_cb, &call_counter, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
-    fail_if(call_counter <= 0);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
+    ck_assert_int_gt(call_counter, 0);
     close(fd);
 
-    fail_if(ml->filename == NULL);
-    fail_if(strcmp(ml->filename, "repomd.xml"));
-    fail_if(ml->timestamp != 0);
-    fail_if(ml->size != 0);
-    fail_if(g_slist_length(ml->hashes) != 4);
-    fail_if(g_slist_length(ml->urls) != 4);
-    fail_if(g_slist_length(ml->alternates) != 0);
+    ck_assert_ptr_nonnull(ml->filename);
+    ck_assert_str_eq(ml->filename, "repomd.xml");
+    ck_assert(ml->timestamp == 0);
+    ck_assert(ml->size == 0);
+    ck_assert(g_slist_length(ml->hashes) == 4);
+    ck_assert(g_slist_length(ml->urls) == 4);
+    ck_assert(g_slist_length(ml->alternates) == 0);
 
     elem = g_slist_nth(ml->hashes, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "md5"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value,
-                    "20b6d77930574ae541108e8e7987ad3f"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "md5");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "20b6d77930574ae541108e8e7987ad3f");
 
     elem = g_slist_nth(ml->hashes, 1);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "foo"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, ""));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "foo");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "");
 
     elem = g_slist_nth(ml->hashes, 2);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "sha256"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value,
-                    "0076c44aabd352da878d5c4d794901ac87f66afac869488f6a4ef166de018cdf"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "sha256");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "0076c44aabd352da878d5c4d794901ac87f66afac869488f6a4ef166de018cdf");
 
     elem = g_slist_nth(ml->hashes, 3);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "sha512"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value,
-                    "884dc465da67fee8fe3f11dab321a99d9a13b22ce97f84ceff210e82b6b1a8c635ccd196add1dd738807686714c3a0a048897e2d0650bc05302b3ee26de521fd"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "sha512");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value,
+                    "884dc465da67fee8fe3f11dab321a99d9a13b22ce97f84ceff210e82b6b1a8c635ccd196add1dd738807686714c3a0a048897e2d0650bc05302b3ee26de521fd");
 
     elem = g_slist_nth(ml->urls, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol == NULL);
-    fail_if(strcmp(mlurl->protocol, "http"));
-    fail_if(mlurl->type == NULL);
-    fail_if(strcmp(mlurl->type, "http"));
-    fail_if(mlurl->location == NULL);
-    fail_if(strcmp(mlurl->location, "US"));
-    fail_if(mlurl->preference != 0);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_nonnull(mlurl->protocol);
+    ck_assert_str_eq(mlurl->protocol, "http");
+    ck_assert_ptr_nonnull(mlurl->type);
+    ck_assert_str_eq(mlurl->type, "http");
+    ck_assert_ptr_nonnull(mlurl->location);
+    ck_assert_str_eq(mlurl->location, "US");
+    ck_assert(mlurl->preference == 0);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "http://mirror.pnl.gov/fedora/linux/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     elem = g_slist_nth(ml->urls, 1);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol != NULL);
-    fail_if(mlurl->type != NULL);
-    fail_if(mlurl->location != NULL);
-    fail_if(mlurl->preference < 0 || mlurl->preference > 100);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "ftp://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_null(mlurl->protocol);
+    ck_assert_ptr_null(mlurl->type);
+    ck_assert_ptr_null(mlurl->location);
+    ck_assert(mlurl->preference >= 0 && mlurl->preference <= 100);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "ftp://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     elem = g_slist_nth(ml->urls, 2);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol != NULL);
-    fail_if(mlurl->type != NULL);
-    fail_if(mlurl->location != NULL);
-    fail_if(mlurl->preference != 0);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url,
-                   "rsync://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml"));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_null(mlurl->protocol);
+    ck_assert_ptr_null(mlurl->type);
+    ck_assert_ptr_null(mlurl->location);
+    ck_assert(mlurl->preference == 0);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url,
+                   "rsync://mirrors.syringanetworks.net/fedora/releases/17/Everything/x86_64/os/repodata/repomd.xml");
 
     elem = g_slist_nth(ml->urls, 3);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlurl = elem->data;
-    fail_if(!mlurl);
-    fail_if(mlurl->protocol != NULL);
-    fail_if(mlurl->type != NULL);
-    fail_if(mlurl->location != NULL);
-    fail_if(mlurl->preference != 0);
-    fail_if(mlurl->url == NULL);
-    fail_if(strcmp(mlurl->url, ""));
+    ck_assert_ptr_nonnull(mlurl);
+    ck_assert_ptr_null(mlurl->protocol);
+    ck_assert_ptr_null(mlurl->type);
+    ck_assert_ptr_null(mlurl->location);
+    ck_assert(mlurl->preference == 0);
+    ck_assert_ptr_nonnull(mlurl->url);
+    ck_assert_str_eq(mlurl->url, "");
 
     lr_metalink_free(ml);
 }
@@ -374,14 +372,14 @@ START_TEST(test_metalink_bad_02)
                          "metalink_bad_02", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
     close(fd);
-    fail_if(g_slist_length(ml->urls) != 0);
+    ck_assert(g_slist_length(ml->urls) == 0);
     lr_metalink_free(ml);
 }
 END_TEST
@@ -398,12 +396,12 @@ START_TEST(test_metalink_really_bad_01)
                          "metalink_really_bad_01", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     close(fd);
     lr_metalink_free(ml);
@@ -422,12 +420,12 @@ START_TEST(test_metalink_really_bad_02)
                          "metalink_really_bad_02", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     close(fd);
     lr_metalink_free(ml);
@@ -446,12 +444,12 @@ START_TEST(test_metalink_really_bad_03)
                          "metalink_really_bad_03", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(ret);
-    fail_if(!tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
     g_error_free(tmp_err);
     close(fd);
     lr_metalink_free(ml);
@@ -473,41 +471,41 @@ START_TEST(test_metalink_with_alternates)
                          "metalink_with_alternates", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_metalink_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_metalink_parse_file(ml, fd, REPOMD, NULL, NULL, &tmp_err);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
     close(fd);
 
-    fail_if(ml->filename == NULL);
-    fail_if(strcmp(ml->filename, "repomd.xml"));
-    fail_if(g_slist_length(ml->hashes) != 4);
-    fail_if(g_slist_length(ml->alternates) != 1);
+    ck_assert_ptr_nonnull(ml->filename);
+    ck_assert_str_eq(ml->filename, "repomd.xml");
+    ck_assert(g_slist_length(ml->hashes) == 4);
+    ck_assert(g_slist_length(ml->alternates) == 1);
 
     elem = g_slist_nth(ml->hashes, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "md5"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "0ffcd7798421c9a6760f3e4202cc4675"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "md5");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "0ffcd7798421c9a6760f3e4202cc4675");
 
     elem = g_slist_nth(ml->alternates, 0);
-    fail_if(!elem);
+    ck_assert_ptr_nonnull(elem);
     malternate = elem->data;
-    fail_if(malternate->timestamp != 1381706941);
-    fail_if(malternate->size != 4761);
-    fail_if(g_slist_length(malternate->hashes) != 4);
+    ck_assert(malternate->timestamp == 1381706941);
+    ck_assert(malternate->size == 4761);
+    ck_assert(g_slist_length(malternate->hashes) == 4);
     elem = g_slist_nth(malternate->hashes, 0);
     mlhash = elem->data;
-    fail_if(!mlhash);
-    fail_if(mlhash->type == NULL);
-    fail_if(strcmp(mlhash->type, "md5"));
-    fail_if(mlhash->value == NULL);
-    fail_if(strcmp(mlhash->value, "0c5b64d395d5364633df7c8e97a07fd6"));
+    ck_assert_ptr_nonnull(mlhash);
+    ck_assert_ptr_nonnull(mlhash->type);
+    ck_assert_str_eq(mlhash->type, "md5");
+    ck_assert_ptr_nonnull(mlhash->value);
+    ck_assert_str_eq(mlhash->value, "0c5b64d395d5364633df7c8e97a07fd6");
 
     lr_metalink_free(ml);
 }

--- a/tests/test_mirrorlist.c
+++ b/tests/test_mirrorlist.c
@@ -18,7 +18,7 @@ START_TEST(test_mirrorlist_init)
     LrMirrorlist *ml = NULL;
 
     ml = lr_mirrorlist_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     lr_mirrorlist_free(ml);
 }
 END_TEST
@@ -36,23 +36,23 @@ START_TEST(test_mirrorlist_01)
                          "mirrorlist_01", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_mirrorlist_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_mirrorlist_parse_file(ml, fd, &tmp_err);
     close(fd);
-    fail_if(!ret);
-    fail_if(tmp_err);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
 
-    fail_if(g_slist_length(ml->urls) != 2);
+    ck_assert(g_slist_length(ml->urls) == 2);
 
     elem = g_slist_nth(ml->urls, 0);
-    fail_if(!elem);
-    fail_if(g_strcmp0(elem->data, "http://foo.bar/fedora/linux/"));
+    ck_assert_ptr_nonnull(elem);
+    ck_assert_str_eq(elem->data, "http://foo.bar/fedora/linux/");
 
     elem = g_slist_nth(ml->urls, 1);
-    fail_if(!elem);
-    fail_if(g_strcmp0(elem->data, "ftp://ftp.bar.foo/Fedora/17/"));
+    ck_assert_ptr_nonnull(elem);
+    ck_assert_str_eq(elem->data, "ftp://ftp.bar.foo/Fedora/17/");
     lr_mirrorlist_free(ml);
 }
 END_TEST
@@ -69,14 +69,14 @@ START_TEST(test_mirrorlist_02)
                          "mirrorlist_02", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_mirrorlist_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_mirrorlist_parse_file(ml, fd, &tmp_err);
     close(fd);
-    fail_if(!ret);
-    fail_if(tmp_err);
-    fail_if(g_slist_length(ml->urls) != 0);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(g_slist_length(ml->urls) == 0);
     lr_mirrorlist_free(ml);
 }
 END_TEST
@@ -93,14 +93,14 @@ START_TEST(test_mirrorlist_03)
                          "mirrorlist_03", NULL);
     fd = open(path, O_RDONLY);
     lr_free(path);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     ml = lr_mirrorlist_init();
-    fail_if(ml == NULL);
+    ck_assert_ptr_nonnull(ml);
     ret = lr_mirrorlist_parse_file(ml, fd, &tmp_err);
     close(fd);
-    fail_if(!ret);
-    fail_if(tmp_err);
-    fail_if(g_slist_length(ml->urls) != 0);
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(g_slist_length(ml->urls) == 0);
     lr_mirrorlist_free(ml);
 }
 END_TEST

--- a/tests/test_package_downloader.c
+++ b/tests/test_package_downloader.c
@@ -25,19 +25,19 @@ START_TEST(test_package_downloader_new_and_free)
 
     target = lr_packagetarget_new(NULL, "url", NULL, 0, NULL, 0, NULL, FALSE,
                                   NULL, NULL, &err);
-    fail_if(!target);
-    fail_if(err);
+    ck_assert_ptr_nonnull(target);
+    ck_assert_ptr_null(err);
 
-    fail_if(strcmp(target->relative_url, "url"));
-    fail_if(target->dest);
-    fail_if(target->base_url);
-    fail_if(target->checksum_type != 0);
-    fail_if(target->checksum);
-    fail_if(target->resume != FALSE);
-    fail_if(target->progresscb);
-    fail_if(target->cbdata);
-    fail_if(target->local_path);
-    fail_if(target->err);
+    ck_assert_str_eq(target->relative_url, "url");
+    ck_assert_ptr_null(target->dest);
+    ck_assert_ptr_null(target->base_url);
+    ck_assert(target->checksum_type == 0);
+    ck_assert_ptr_null(target->checksum);
+    ck_assert(target->resume == FALSE);
+    ck_assert(!target->progresscb);
+    ck_assert_ptr_null(target->cbdata);
+    ck_assert_ptr_null(target->local_path);
+    ck_assert_ptr_null(target->err);
 
     lr_packagetarget_free(target);
     target = NULL;
@@ -47,19 +47,19 @@ START_TEST(test_package_downloader_new_and_free)
     target = lr_packagetarget_new(NULL, "url", "dest", LR_CHECKSUM_SHA384,
                                   "xxx", 0, "baseurl", TRUE, (LrProgressCb) 22,
                                   (void *) 33, &err);
-    fail_if(!target);
-    fail_if(err);
+    ck_assert_ptr_nonnull(target);
+    ck_assert_ptr_null(err);
 
-    fail_if(strcmp(target->relative_url, "url"));
-    fail_if(strcmp(target->dest, "dest"));
-    fail_if(strcmp(target->base_url, "baseurl"));
-    fail_if(target->checksum_type != LR_CHECKSUM_SHA384);
-    fail_if(strcmp(target->checksum, "xxx"));
-    fail_if(target->resume != TRUE);
-    fail_if(target->progresscb != (LrProgressCb) 22);
-    fail_if(target->cbdata != (void *) 33);
-    fail_if(target->local_path);
-    fail_if(target->err);
+    ck_assert_str_eq(target->relative_url, "url");
+    ck_assert_str_eq(target->dest, "dest");
+    ck_assert_str_eq(target->base_url, "baseurl");
+    ck_assert(target->checksum_type == LR_CHECKSUM_SHA384);
+    ck_assert_str_eq(target->checksum, "xxx");
+    ck_assert(target->resume == TRUE);
+    ck_assert(target->progresscb == (LrProgressCb) 22);
+    ck_assert_ptr_eq(target->cbdata, (void *) 33);
+    ck_assert_ptr_null(target->local_path);
+    ck_assert_ptr_null(target->err);
 
     lr_packagetarget_free(target);
     target = NULL;

--- a/tests/test_repo_zck.c
+++ b/tests/test_repo_zck.c
@@ -23,22 +23,22 @@ START_TEST(test_repo_zck_parsing)
                                 "repo_yum_03/repodata/repomd.xml",
                                 NULL);
     repomd = lr_yum_repomd_init();
-    fail_if(!repomd);
+    ck_assert_ptr_nonnull(repomd);
     fd = open(repomd_path, O_RDONLY);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
 
     ret = lr_yum_repomd_parse_file(repomd, fd, NULL, NULL, &tmp_err);
     close(fd);
 
-    fail_if(!ret);
-    fail_if(tmp_err);
-    fail_if(g_slist_length(repomd->records) != 12);
-    fail_if(!lr_yum_repomd_get_record(repomd, "primary"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "filelists"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "other"));
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(g_slist_length(repomd->records) == 12);
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "primary"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "filelists"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "other"));
 
-    fail_if(lr_yum_repomd_get_record(repomd, "foo"));
-    fail_if(lr_yum_repomd_get_record(repomd, "bar"));
+    ck_assert_ptr_null(lr_yum_repomd_get_record(repomd, "foo"));
+    ck_assert_ptr_null(lr_yum_repomd_get_record(repomd, "bar"));
 
     lr_yum_repomd_free(repomd);
     lr_free(repomd_path);

--- a/tests/test_repoconf.c
+++ b/tests/test_repoconf.c
@@ -304,19 +304,19 @@ START_TEST(test_parse_repoconf_minimal)
     path = lr_pathconcat(test_globals.testdata_dir, "repo-minimal.repo", NULL);
 
     confs = lr_yum_repoconfs_init();
-    fail_if(!confs);
+    ck_assert_ptr_nonnull(confs);
 
     ret = lr_yum_repoconfs_parse(confs, path, &tmp_err);
-    fail_if(!ret);
+    ck_assert(ret);
 
     list = lr_yum_repoconfs_get_list(confs, &tmp_err);
-    fail_if(!list);
-    fail_if(g_slist_length(list) != 2);
+    ck_assert_ptr_nonnull(list);
+    ck_assert(g_slist_length(list) == 2);
 
     // Test content of first repo config
 
     conf = g_slist_nth_data(list, 0);
-    fail_if(!conf);
+    ck_assert_ptr_nonnull(conf);
 
     conf_assert_str_eq(LR_YRC_ID, "minimal-repo-1");
     conf_assert_str_eq(LR_YRC_NAME, "Minimal repo 1 - $basearch");
@@ -363,7 +363,7 @@ START_TEST(test_parse_repoconf_minimal)
     // Test content of second repo config
 
     conf = g_slist_nth_data(list, 1);
-    fail_if(!conf);
+    ck_assert_ptr_nonnull(conf);
 
     conf_assert_str_eq(LR_YRC_ID, "minimal-repo-2");
     conf_assert_str_eq(LR_YRC_NAME, "Minimal repo 2 - $basearch");
@@ -423,17 +423,17 @@ START_TEST(test_parse_repoconf_big)
     path = lr_pathconcat(test_globals.testdata_dir, "repo-big.repo", NULL);
 
     confs = lr_yum_repoconfs_init();
-    fail_if(!confs);
+    ck_assert_ptr_nonnull(confs);
 
     ret = lr_yum_repoconfs_parse(confs, path, &tmp_err);
-    fail_if(!ret);
+    ck_assert(ret);
 
     list = lr_yum_repoconfs_get_list(confs, &tmp_err);
-    fail_if(!list);
-    fail_if(g_slist_length(list) != 1);
+    ck_assert_ptr_nonnull(list);
+    ck_assert(g_slist_length(list) == 1);
 
     conf = g_slist_nth_data(list, 0);
-    fail_if(!conf);
+    ck_assert_ptr_nonnull(conf);
 
     conf_assert_str_eq(LR_YRC_ID, "big-repo");
     conf_assert_str_eq(LR_YRC_NAME, "Maxi repo - $basearch");
@@ -504,7 +504,7 @@ START_TEST(test_write_repoconf)
 
     // Create a temporary file
     fd = mkstemp(tmpfn);
-    fail_if(fd == -1);
+    ck_assert_int_ne(fd, -1);
 
     // Create reconfs with one repoconf with one id (one section)
     confs = lr_yum_repoconfs_init();

--- a/tests/test_repomd.c
+++ b/tests/test_repomd.c
@@ -23,31 +23,31 @@ START_TEST(test_repomd_parsing)
                                 "repo_yum_02/repodata/repomd.xml",
                                 NULL);
     repomd = lr_yum_repomd_init();
-    fail_if(!repomd);
+    ck_assert_ptr_nonnull(repomd);
     fd = open(repomd_path, O_RDONLY);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
 
     ret = lr_yum_repomd_parse_file(repomd, fd, NULL, NULL, &tmp_err);
     close(fd);
 
-    fail_if(!ret);
-    fail_if(tmp_err);
-    fail_if(g_slist_length(repomd->records) != 12);
-    fail_if(!lr_yum_repomd_get_record(repomd, "primary"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "filelists"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "other"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "primary_db"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "filelists_db"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "other_db"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "group"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "group_gz"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "updateinfo"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "origin"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "prestodelta"));
-    fail_if(!lr_yum_repomd_get_record(repomd, "deltainfo"));
+    ck_assert(ret);
+    ck_assert_ptr_null(tmp_err);
+    ck_assert(g_slist_length(repomd->records) == 12);
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "primary"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "filelists"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "other"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "primary_db"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "filelists_db"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "other_db"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "group"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "group_gz"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "updateinfo"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "origin"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "prestodelta"));
+    ck_assert_ptr_nonnull(lr_yum_repomd_get_record(repomd, "deltainfo"));
 
-    fail_if(lr_yum_repomd_get_record(repomd, "foo"));
-    fail_if(lr_yum_repomd_get_record(repomd, "bar"));
+    ck_assert_ptr_null(lr_yum_repomd_get_record(repomd, "foo"));
+    ck_assert_ptr_null(lr_yum_repomd_get_record(repomd, "bar"));
 
     lr_yum_repomd_free(repomd);
     lr_free(repomd_path);

--- a/tests/test_url_substitution.c
+++ b/tests/test_url_substitution.c
@@ -20,22 +20,22 @@ START_TEST(test_urlvars_set)
     LrUrlVars *urlvars = NULL;
 
     urlvars = lr_urlvars_set(urlvars, "foo", "bar");
-    fail_if(urlvars == NULL);
-    fail_if(strcmp(((LrVar *)urlvars->data)->var, "foo") != 0);
+    ck_assert_ptr_nonnull(urlvars);
+    ck_assert_str_eq(((LrVar *)urlvars->data)->var, "foo");
 
     urlvars = lr_urlvars_set(urlvars, "foo1", "bar1");
-    fail_if(urlvars == NULL);
+    ck_assert_ptr_nonnull(urlvars);
 
     urlvars = lr_urlvars_set(urlvars, "foo", NULL);
-    fail_if(urlvars == NULL);
-    fail_if(strcmp(((LrVar *)urlvars->data)->var, "foo1") != 0);
+    ck_assert_ptr_nonnull(urlvars);
+    ck_assert_str_eq(((LrVar *)urlvars->data)->var, "foo1");
 
     urlvars = lr_urlvars_set(urlvars, "foo1", NULL);
-    fail_if(urlvars != NULL);
+    ck_assert_ptr_null(urlvars);
 
     urlvars = lr_urlvars_set(urlvars, "bar", "foo");
-    fail_if(urlvars == NULL);
-    fail_if(strcmp(((LrVar *)urlvars->data)->var, "bar") != 0);
+    ck_assert_ptr_nonnull(urlvars);
+    ck_assert_str_eq(((LrVar *)urlvars->data)->var, "bar");
 
     lr_urlvars_free(urlvars);
 }
@@ -49,19 +49,19 @@ START_TEST(test_url_substitute_without_urlvars)
     urlvars = lr_urlvars_set(urlvars, "foo", "bar");
 
     url = lr_url_substitute("", urlvars);
-    fail_if(strcmp(url, ""));
+    ck_assert_str_eq(url, "");
     lr_free(url);
 
     url = lr_url_substitute("http://foo", urlvars);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
     lr_free(url);
 
     url = lr_url_substitute("http://foo?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://foo?id=$bar"));
+    ck_assert_str_eq(url, "http://foo?id=$bar");
     lr_free(url);
 
     url = lr_url_substitute("http://foo?id=$foox", urlvars);
-    fail_if(strcmp(url, "http://foo?id=$foox"));
+    ck_assert_str_eq(url, "http://foo?id=$foox");
     lr_free(url);
 
     lr_urlvars_free(urlvars);
@@ -78,31 +78,31 @@ START_TEST(test_url_substitute)
     urlvars = lr_urlvars_set(urlvars, "bar", "repo");
 
     url = lr_url_substitute("", urlvars);
-    fail_if(strcmp(url, ""));
+    ck_assert_str_eq(url, "");
     lr_free(url);
 
     url = lr_url_substitute("http://foo", urlvars);
-    fail_if(strcmp(url, "http://foo"));
+    ck_assert_str_eq(url, "http://foo");
     lr_free(url);
 
     url = lr_url_substitute("http://foo?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://foo?id=repo"));
+    ck_assert_str_eq(url, "http://foo?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://$foo?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://version?id=repo"));
+    ck_assert_str_eq(url, "http://version?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://$fo?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://ver?id=repo"));
+    ck_assert_str_eq(url, "http://ver?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://$foo$bar", urlvars);
-    fail_if(strcmp(url, "http://versionrepo"));
+    ck_assert_str_eq(url, "http://versionrepo");
     lr_free(url);
 
     url = lr_url_substitute("http://$foo$bar/", urlvars);
-    fail_if(strcmp(url, "http://versionrepo/"));
+    ck_assert_str_eq(url, "http://versionrepo/");
     lr_free(url);
 
     lr_urlvars_free(urlvars);
@@ -119,27 +119,27 @@ START_TEST(test_url_substitute_braces)
     urlvars = lr_urlvars_set(urlvars, "bar", "repo");
 
     url = lr_url_substitute("http://foo?id=${bar}", urlvars);
-    fail_if(strcmp(url, "http://foo?id=repo"));
+    ck_assert_str_eq(url, "http://foo?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://${foo}?id=${bar}", urlvars);
-    fail_if(strcmp(url, "http://version?id=repo"));
+    ck_assert_str_eq(url, "http://version?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://${fo}?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://ver?id=repo"));
+    ck_assert_str_eq(url, "http://ver?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://${fo?id=$bar", urlvars);
-    fail_if(strcmp(url, "http://${fo?id=repo"));
+    ck_assert_str_eq(url, "http://${fo?id=repo");
     lr_free(url);
 
     url = lr_url_substitute("http://${foo${bar}", urlvars);
-    fail_if(strcmp(url, "http://${foorepo"));
+    ck_assert_str_eq(url, "http://${foorepo");
     lr_free(url);
 
     url = lr_url_substitute("http://${foo}${bar}/", urlvars);
-    fail_if(strcmp(url, "http://versionrepo/"));
+    ck_assert_str_eq(url, "http://versionrepo/");
     lr_free(url);
 
     lr_urlvars_free(urlvars);

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -18,7 +18,7 @@ START_TEST(test_malloc)
 {
     long long *num = NULL;
     num = lr_malloc0(sizeof(long long));
-    fail_if(num == NULL);
+    ck_assert_ptr_nonnull(num);
     lr_free(num);
 }
 END_TEST
@@ -27,8 +27,8 @@ START_TEST(test_malloc0)
 {
     long long *num = NULL;
     num = lr_malloc0(sizeof(long long));
-    fail_if(num == NULL);
-    fail_if(*num != 0LL);
+    ck_assert_ptr_nonnull(num);
+    ck_assert(*num == 0LL);
     lr_free(num);
 }
 END_TEST
@@ -44,7 +44,7 @@ START_TEST(test_gettmpfile)
 {
     int fd = 0;
     fd = lr_gettmpfile();
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     close(fd);
 }
 END_TEST
@@ -52,8 +52,8 @@ END_TEST
 START_TEST(test_gettmpdir)
 {
     char *tmp_dir = lr_gettmpdir();
-    fail_if(tmp_dir == NULL);
-    fail_if(rmdir(tmp_dir) != 0);
+    ck_assert_ptr_nonnull(tmp_dir);
+    ck_assert_int_eq(rmdir(tmp_dir), 0);
     lr_free(tmp_dir);
 }
 END_TEST
@@ -63,47 +63,47 @@ START_TEST(test_pathconcat)
     char *path = NULL;
 
     path = lr_pathconcat(NULL, NULL);
-    fail_if(path != NULL);
+    ck_assert_ptr_null(path);
 
     path = lr_pathconcat("", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, ""));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("/tmp", "foo///", "bar", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "/tmp/foo/bar"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "/tmp/foo/bar");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("foo", "bar/", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "foo/bar"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "foo/bar");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("foo", "/bar/", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "foo/bar"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "foo/bar");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("foo", "bar", "", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "foo/bar/"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "foo/bar/");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("http://host.net", "path/to/somewhere", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "http://host.net/path/to/somewhere"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "http://host.net/path/to/somewhere");
     lr_free(path);
     path = NULL;
 
     path = lr_pathconcat("http://host.net?hello=1", "path/to/", "somewhere", NULL);
-    fail_if(path == NULL);
-    fail_if(strcmp(path, "http://host.net/path/to/somewhere?hello=1"));
+    ck_assert_ptr_nonnull(path);
+    ck_assert_str_eq(path, "http://host.net/path/to/somewhere?hello=1");
     lr_free(path);
     path = NULL;
 }
@@ -116,16 +116,16 @@ START_TEST(test_remove_dir)
     int fd, rc;
 
     tmp_dir = lr_gettmpdir();
-    fail_if(tmp_dir == NULL);
+    ck_assert_ptr_nonnull(tmp_dir);
     tmp_file = lr_pathconcat(tmp_dir, "file_a", NULL);
     fd = open(tmp_file, O_CREAT|O_TRUNC|O_RDWR, 0660);
-    fail_if(fd < 0);
+    ck_assert_int_ge(fd, 0);
     close(fd);
 
     rc = lr_remove_dir(tmp_dir);
-    fail_if(rc != 0);
-    fail_if(unlink(tmp_file) == 0);
-    fail_if(rmdir(tmp_dir) == 0);
+    ck_assert_int_eq(rc, 0);
+    ck_assert_int_ne(unlink(tmp_file), 0);
+    ck_assert_int_ne(rmdir(tmp_dir), 0);
     lr_free(tmp_dir);
     lr_free(tmp_file);
 }
@@ -136,65 +136,65 @@ START_TEST(test_url_without_path)
     char *new_url = NULL;
 
     new_url = lr_url_without_path(NULL);
-    fail_if(new_url != NULL);
+    ck_assert_ptr_null(new_url);
 
     new_url = lr_url_without_path("");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, ""));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("hostname");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "hostname"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "hostname");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("hostname/foo/bar/");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "hostname"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "hostname");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("hostname:80");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "hostname:80"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "hostname:80");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("hostname:80/foo/bar");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "hostname:80"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "hostname:80");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("http://hostname:80/");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "http://hostname:80"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "http://hostname:80");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("http://hostname:80/foo/bar");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "http://hostname:80"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "http://hostname:80");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("ftp://foo.hostname:80/foo/bar");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "ftp://foo.hostname:80"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "ftp://foo.hostname:80");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("file:///home/foobar");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "file://"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "file://");
     lr_free(new_url);
     new_url = NULL;
 
     new_url = lr_url_without_path("file:/home/foobar");
-    fail_if(new_url == NULL);
-    fail_if(strcmp(new_url, "file://"));
+    ck_assert_ptr_nonnull(new_url);
+    ck_assert_str_eq(new_url, "file://");
     lr_free(new_url);
     new_url = NULL;
 }
@@ -209,39 +209,39 @@ START_TEST(test_strv_dup)
     gchar **copy = NULL;
 
     copy = lr_strv_dup(in0);
-    fail_if(copy != NULL);
+    ck_assert_ptr_null(copy);
 
     copy = lr_strv_dup(in1);
-    fail_if(!copy);
-    fail_if(copy == in1);
-    fail_if(copy[0] != NULL);
+    ck_assert(copy);
+    ck_assert_ptr_ne(copy, in1);
+    ck_assert_ptr_null(copy[0]);
     g_strfreev(copy);
 
     copy = lr_strv_dup(in2);
-    fail_if(!copy);
-    fail_if(copy == in2);
-    fail_if(g_strcmp0(copy[0], "foo"));
-    fail_if(copy[0] == in2[0]);
-    fail_if(copy[1] != NULL);
+    ck_assert(copy);
+    ck_assert_ptr_ne(copy, in2);
+    ck_assert_str_eq(copy[0], "foo");
+    ck_assert_ptr_ne(copy[0], in2[0]);
+    ck_assert_ptr_null(copy[1]);
     g_strfreev(copy);
 }
 END_TEST
 
 START_TEST(test_is_local_path)
 {
-    fail_if(!lr_is_local_path("/tmp"));
-    fail_if(!lr_is_local_path("foo/bar"));
-    fail_if(!lr_is_local_path("bar"));
-    fail_if(!lr_is_local_path("/"));
-    fail_if(!lr_is_local_path("file:///tmp"));
-    fail_if(!lr_is_local_path("file:/tmp"));
+    ck_assert(lr_is_local_path("/tmp"));
+    ck_assert(lr_is_local_path("foo/bar"));
+    ck_assert(lr_is_local_path("bar"));
+    ck_assert(lr_is_local_path("/"));
+    ck_assert(lr_is_local_path("file:///tmp"));
+    ck_assert(lr_is_local_path("file:/tmp"));
 
-    fail_if(lr_is_local_path(NULL));
-    fail_if(lr_is_local_path(""));
-    fail_if(lr_is_local_path("http://foo.bar"));
-    fail_if(lr_is_local_path("https://foo.bar/x"));
-    fail_if(lr_is_local_path("ftp://foo.bar/foobar"));
-    fail_if(lr_is_local_path("rsync://xyz"));
+    ck_assert(!lr_is_local_path(NULL));
+    ck_assert(!lr_is_local_path(""));
+    ck_assert(!lr_is_local_path("http://foo.bar"));
+    ck_assert(!lr_is_local_path("https://foo.bar/x"));
+    ck_assert(!lr_is_local_path("ftp://foo.bar/foobar"));
+    ck_assert(!lr_is_local_path("rsync://xyz"));
 }
 END_TEST
 
@@ -250,19 +250,19 @@ START_TEST(test_prepend_url_protocol)
     gchar *url = NULL;
 
     url = lr_prepend_url_protocol("/tmp");
-    fail_if(g_strcmp0(url, "file:///tmp"));
+    ck_assert_str_eq(url, "file:///tmp");
     g_free(url);
 
     url = lr_prepend_url_protocol("file:///tmp");
-    fail_if(g_strcmp0(url, "file:///tmp"));
+    ck_assert_str_eq(url, "file:///tmp");
     g_free(url);
 
     url = lr_prepend_url_protocol("http://tmp");
-    fail_if(g_strcmp0(url, "http://tmp"));
+    ck_assert_str_eq(url, "http://tmp");
     g_free(url);
 
     url = lr_prepend_url_protocol("file:/tmp");
-    fail_if(g_strcmp0(url, "file:/tmp"));
+    ck_assert_str_eq(url, "file:/tmp");
     g_free(url);
 }
 END_TEST

--- a/tests/test_version.c
+++ b/tests/test_version.c
@@ -10,23 +10,23 @@
 
 START_TEST(test_version_check_macro)
 {
-    fail_if(!(LR_VERSION_CHECK(LR_VERSION_MAJOR,
+    ck_assert(LR_VERSION_CHECK(LR_VERSION_MAJOR,
                                LR_VERSION_MINOR,
-                               LR_VERSION_PATCH)));
+                               LR_VERSION_PATCH));
 
-    fail_if(!(LR_VERSION_CHECK(0, 0, 0)));
+    ck_assert(LR_VERSION_CHECK(0, 0, 0));
 
-    fail_if(LR_VERSION_CHECK(LR_VERSION_MAJOR,
-                             LR_VERSION_MINOR,
-                             LR_VERSION_PATCH+1));
+    ck_assert(!(LR_VERSION_CHECK(LR_VERSION_MAJOR,
+                                 LR_VERSION_MINOR,
+                                 LR_VERSION_PATCH+1)));
 
-    fail_if(LR_VERSION_CHECK(LR_VERSION_MAJOR,
-                             LR_VERSION_MINOR+1,
-                             LR_VERSION_PATCH));
+    ck_assert(!(LR_VERSION_CHECK(LR_VERSION_MAJOR,
+                                 LR_VERSION_MINOR+1,
+                                 LR_VERSION_PATCH)));
 
-    fail_if(LR_VERSION_CHECK(LR_VERSION_MAJOR+1,
-                             LR_VERSION_MINOR,
-                             LR_VERSION_PATCH));
+    ck_assert(!(LR_VERSION_CHECK(LR_VERSION_MAJOR+1,
+                                 LR_VERSION_MINOR,
+                                 LR_VERSION_PATCH)));
 }
 END_TEST
 


### PR DESCRIPTION
https://libcheck.github.io/check/doc/check_html/check_4.html#Convenience-Test-Functions

It also fixes a couple of covscan warnings of the following type:
```
Error: COMPILER_WARNING (CWE-685):
librepo-1.12.1/tests/fixtures.h:5: included_from: Included from here.
librepo-1.12.1/tests/test_checksum.c:15: included_from: Included from here.
librepo-1.12.1/tests/test_checksum.c: scope_hint: In function 'test_checksum'
librepo-1.12.1/tests/test_checksum.c:58:9: warning[-Wformat-extra-args]: too many arguments for format
\#   58 |         "Checksum is %s instead of %s", checksum, expected);
\#      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
\#   56|       fail_if(tmp_err);
\#   57|       fail_if(strcmp(checksum, expected),
\#   58|->         "Checksum is %s instead of %s", checksum, expected);
\#   59|       lr_free(checksum);
\#   60|       close(fd);
```