### PR TITLE
Update libattr URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Fedora/Ubuntu name
 * gcc (http://gcc.gnu.org/) - gcc/gcc
 * glib2 (http://developer.gnome.org/glib/) - glib2-devel/libglib2.0-dev
 * gpgme (http://www.gnupg.org/) - gpgme-devel/libgpgme11-dev
-* libattr (http://www.bestbits.at/acl/) - libattr-devel/libattr1-dev
+* libattr (https://savannah.nongnu.org/projects/attr) - libattr-devel/libattr1-dev
 * libcurl (http://curl.haxx.se/libcurl/) - libcurl-devel/libcurl4-openssl-dev
 * openssl (http://www.openssl.org/) - openssl-devel/libssl-dev
 * python (http://python.org/) - python3-devel/libpython3-dev


### PR DESCRIPTION
Porting librepo for IBM i, ran into the libattr dependency. Current URL in the README timedout. Found the new URL for the project at: https://savannah.nongnu.org/projects/attr/

This is the URL used in both the [Fedora](https://src.fedoraproject.org/rpms/attr/blob/rawhide/f/attr.spec) and [Ubunutu](https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/libattr1-dev_2.4.48-5_amd64.deb.html) packages.