### PR TITLE
Detailed error message when using non-existing TMPDIR (RhBug:2019993)

### DIFF
--- a/librepo/util.c
+++ b/librepo/util.c
@@ -158,7 +158,7 @@ lr_gettmpfile(void)
     template = g_build_filename(g_get_tmp_dir(), "librepo-tmp-XXXXXX", NULL);
     fd = mkstemp(template);
     if (fd < 0) {
-        perror("Cannot create temporary file - mkstemp");
+        fprintf(stderr, "Cannot create temporary file - mkstemp '%s': %s\n", template, strerror(errno));
         exit(1);
     }
     unlink(template);


### PR DESCRIPTION
Show detailed info about missing temporary directory when `TMPDIR` directory was removed or the environmental variable was unset before its processing during `dnf` command.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2019993.