### PR TITLE
metadata_downloader: Include unistd.h for lseek()

### DIFF
--- a/librepo/metadata_downloader.c
+++ b/librepo/metadata_downloader.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 #include "librepo/librepo.h"


### PR DESCRIPTION
This is found when compiling on musl systems

Fixes

metadata_downloader.c:331:9: error: call to undeclared function 'lseek'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        lseek(fd_value, SEEK_SET, 0);
        ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>