### PR TITLE
Update license format to LGPL-2.1-or-later

### DIFF
--- a/librepo.spec
+++ b/librepo.spec
@@ -15,7 +15,7 @@ Version:        1.14.0
 Release:        1%{?dist}
 Summary:        Repodata downloading library
 
-License:        LGPLv2+
+License:        LGPL-2.1-or-later
 URL:            https://github.com/rpm-software-management/librepo
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 


### PR DESCRIPTION
This is NOT relicensing. Due to recent changes in Fedora's License
Format, this commit updates the License field adopting SPDX.

=changelog=
msg: Update License format to LGPL-2.1-or-later
type: enhancement

How to license in Fedora:
https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/#_license_field
Packages that need license format updates:
https://pagure.io/copr/license-validate/raw/main/f/packages-without-spdx-final.txt