### PR TITLE
librepo.h: Change how project files are included

### DIFF
--- a/librepo/CMakeLists.txt
+++ b/librepo/CMakeLists.txt
@@ -42,7 +42,6 @@ SET(librepo_HEADERS
     xmlparser.h
     yum.h
     downloader.h
-    downloader_internal.h
     downloadtarget.h)
 
 ADD_LIBRARY(librepo SHARED ${librepo_SRCS})

--- a/librepo/CMakeLists.txt
+++ b/librepo/CMakeLists.txt
@@ -44,7 +44,18 @@ SET(librepo_HEADERS
     downloader.h
     downloadtarget.h)
 
-ADD_LIBRARY(librepo SHARED ${librepo_SRCS})
+SET(librepo_internal_HEADERS
+    downloader_internal.h
+    downloadtarget_internal.h
+    fastestmirror_internal.h
+    handle_internal.h
+    repoconf_internal.h
+    result_internal.h
+    xattr_internal.h
+    xmlparser_internal.h
+    yum_internal.h)
+
+ADD_LIBRARY(librepo SHARED ${librepo_SRCS} ${librepo_HEADERS} ${librepo_internal_HEADERS})
 TARGET_LINK_LIBRARIES(librepo
                         ${LIBXML2_LIBRARIES}
                         ${CURL_LIBRARY}

--- a/librepo/downloader.h
+++ b/librepo/downloader.h
@@ -23,8 +23,8 @@
 
 #include <glib.h>
 
-#include "handle.h"
-#include "downloadtarget.h"
+#include <librepo/handle.h>
+#include <librepo/downloadtarget.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/downloader_internal.h
+++ b/librepo/downloader_internal.h
@@ -21,7 +21,9 @@
 #ifndef LIBREPO_DOWNLOADER_INTERNAL_H
 #define LIBREPO_DOWNLOADER_INTERNAL_H
 
-#include "handle.h"
+#include <librepo/handle.h>
+
+G_BEGIN_DECLS
 
 typedef struct {
     LrProgressCb cb; /*!<
@@ -41,5 +43,7 @@ typedef struct {
     void *userdata;     /*!< User data related to the target */
     LrSharedCallbackData *sharedcbdata; /*!< Shared cb data */
 } LrCallbackData;
+
+G_END_DECLS
 
 #endif //LIBREPO_DOWNLOADER_INTERNAL_H

--- a/librepo/downloadtarget.h
+++ b/librepo/downloadtarget.h
@@ -27,11 +27,11 @@
 #include <zck.h>
 #endif /* WITH_ZCHUNK */
 
-#include "handle.h"
-#include "rcodes.h"
-#include "checksum.h"
-#include "types.h"
-#include "yum.h"
+#include <librepo/handle.h>
+#include <librepo/rcodes.h>
+#include <librepo/checksum.h>
+#include <librepo/types.h>
+#include <librepo/yum.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/fastestmirror.h
+++ b/librepo/fastestmirror.h
@@ -24,10 +24,10 @@
 #include <glib.h>
 #include <curl/curl.h>
 
-#include "url_substitution.h"
-#include "mirrorlist.h"
-#include "metalink.h"
-#include "handle.h"
+#include <librepo/url_substitution.h>
+#include <librepo/mirrorlist.h>
+#include <librepo/metalink.h>
+#include <librepo/handle.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/handle.h
+++ b/librepo/handle.h
@@ -24,7 +24,7 @@
 #include <glib.h>
 #include <gio/gio.h>
 
-#include "result.h"
+#include <librepo/result.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/metadata_downloader.h
+++ b/librepo/metadata_downloader.h
@@ -23,10 +23,12 @@
 
 #include <glib.h>
 
-#include "yum.h"
-#include "handle.h"
-#include "repomd.h"
-#include "downloadtarget.h"
+#include <librepo/yum.h>
+#include <librepo/handle.h>
+#include <librepo/repomd.h>
+#include <librepo/downloadtarget.h>
+
+G_BEGIN_DECLS
 
 /** LrMetadataTarget structure */
 typedef struct {
@@ -117,5 +119,7 @@ lr_metadatatarget_free(LrMetadataTarget *target);
  */
 gboolean
 lr_download_metadata(GSList *targets, GError **err);
+
+G_END_DECLS
 
 #endif //LIBREPO_METADATA_DOWNLOADER_H

--- a/librepo/metalink.h
+++ b/librepo/metalink.h
@@ -22,7 +22,7 @@
 #define __LR_METALINK_H__
 
 #include <glib.h>
-#include "xmlparser.h"
+#include <librepo/xmlparser.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/package_downloader.h
+++ b/librepo/package_downloader.h
@@ -23,9 +23,9 @@
 
 #include <glib.h>
 
-#include "rcodes.h"
-#include "handle.h"
-#include "checksum.h"
+#include <librepo/rcodes.h>
+#include <librepo/handle.h>
+#include <librepo/checksum.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/repoconf.h
+++ b/librepo/repoconf.h
@@ -22,7 +22,7 @@
 #define __LR_REPOCONF_H__
 
 #include <glib.h>
-#include "types.h"
+#include <librepo/types.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/repomd.h
+++ b/librepo/repomd.h
@@ -23,8 +23,8 @@
 
 #include <glib.h>
 
-#include "xmlparser.h"
-#include "types.h"
+#include <librepo/xmlparser.h>
+#include <librepo/types.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/repoutil_yum.h
+++ b/librepo/repoutil_yum.h
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 
-#include "repomd.h"
+#include <librepo/repomd.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/result.h
+++ b/librepo/result.h
@@ -23,7 +23,7 @@
 
 #include <glib.h>
 
-#include "types.h"
+#include <librepo/types.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/util.h
+++ b/librepo/util.h
@@ -30,9 +30,9 @@
 #include <zck.h>
 #endif /* WITH_ZCHUNK */
 
-#include "checksum.h"
-#include "xmlparser.h"
-#include "downloadtarget.h"
+#include <librepo/checksum.h>
+#include <librepo/xmlparser.h>
+#include <librepo/downloadtarget.h>
 
 G_BEGIN_DECLS
 

--- a/librepo/yum.h
+++ b/librepo/yum.h
@@ -23,11 +23,11 @@
 
 #include <glib.h>
 
-#include "handle.h"
-#include "metalink.h"
-#include "rcodes.h"
-#include "repomd.h"
-#include "result.h"
+#include <librepo/handle.h>
+#include <librepo/metalink.h>
+#include <librepo/rcodes.h>
+#include <librepo/repomd.h>
+#include <librepo/result.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Use path-reference in the public header, to avoid ambiguity for generic-like header files from other projects. Otherwise it would depend on the order of the include directories in the build time, which of the header file is picked.