### PR TITLE
We cannot use the same copr build for dnf4 and dnf5 CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: DNF CI
 on: pull_request_target
 
 jobs:
-  copr-build:
-    name: Copr Build
+  copr-build-dnf4:
+    name: DNF4 Copr Build
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rpm-software-management/dnf-ci-host
@@ -36,9 +36,43 @@ jobs:
         with:
           copr-user: ${{steps.setup-ci.outputs.copr-user}}
 
+  copr-build-dnf5:
+    name: DNF5 Copr Build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rpm-software-management/dnf-ci-host
+    outputs:
+      package-urls: ${{steps.copr-build.outputs.package-urls}}
+    steps:
+      - name: Check out ci-dnf-stack
+        uses: actions/checkout@v2
+        with:
+          repository: rpm-software-management/ci-dnf-stack
+
+      - name: Setup CI
+        id: setup-ci
+        uses: ./.github/actions/setup-ci
+        with:
+          copr-user: ${{secrets.COPR_USER}}
+          copr-api-token: ${{secrets.COPR_API_TOKEN}}
+
+      - name: Check out sources
+        uses: actions/checkout@v2
+        with:
+          path: gits/${{github.event.repository.name}}
+          ref: ${{github.event.pull_request.head.sha}}  # check out the PR HEAD
+          fetch-depth: 0
+
+      - name: Run Copr Build
+        id: copr-build
+        uses: ./.github/actions/copr-build
+        with:
+          copr-user: ${{steps.setup-ci.outputs.copr-user}}
+          overlay: dnf5-ci
+
   integration-tests-dnf4:
     name: DNF4 Integration Tests
-    needs: copr-build
+    needs: copr-build-dnf4
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rpm-software-management/dnf-ci-host
@@ -57,7 +91,7 @@ jobs:
 
   integration-tests-dnf5:
     name: DNF5 Integration Tests
-    needs: copr-build
+    needs: copr-build-dnf5
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rpm-software-management/dnf-ci-host
@@ -79,7 +113,7 @@ jobs:
 
   ansible-tests:
     name: Ansible Tests
-    needs: copr-build
+    needs: copr-build-dnf4
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rpm-software-management/dnf-ci-host


### PR DESCRIPTION
In dnf4 copr build we need microdnf but it is obsoleted by dnf5 (in F38) therefore we need separate builds.

This is an alternative to: https://github.com/rpm-software-management/ci-dnf-stack/pull/1286

Before this we have to fix the microdnf build though.