### PR TITLE
Avoid libc buffered IO

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -148,8 +148,8 @@ typedef struct {
         Current protocol */
     CURL *curl_handle; /*!<
         Used curl handle or NULL */
-    FILE *f; /*!<
-        fdopened file descriptor from LrDownloadTarget and used
+    int fd; /*!<
+        opened file descriptor from LrDownloadTarget and used
         in curl_handle. */
     char errorbuffer[CURL_ERROR_SIZE]; /*!<
         Error buffer used in curl handle */
@@ -283,7 +283,7 @@ typedef struct {
  *       | LrDownloadTarget *target  -----------/   | int fd                   |
  *       | LrMirror *mirror          --------/      | LrChecksumType checks..  |
  *       | CURL *curl_handle          |-+           | char *checksum           |
- *       | FILE *f                    |             | int resume               |
+ *       | int fd                     |             | int resume               |
  *       | GSList *tried_mirrors      |             | LrProgressCb progresscb  |
  *       | gint64 original_offset     |             | void *cbdata             |
  *       | GSlist *lrmirrors         ---\           | GStringChunk *chunk      |
@@ -614,22 +614,51 @@ lr_zck_writecb(char *ptr, size_t size, size_t nmemb, void *userdata)
 size_t
 lr_writecb(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-    size_t cur_written_expected = nmemb;
-    size_t cur_written;
     LrTarget *target = (LrTarget *) userdata;
     #ifdef WITH_ZCHUNK
     if(target->target->is_zchunk && !target->range_fail && target->mirror->mirror->protocol == LR_PROTOCOL_HTTP)
         return lr_zck_writecb(ptr, size, nmemb, userdata);
     #endif /* WITH_ZCHUNK */
 
-    gint64 all = size * nmemb;  // Total number of bytes from curl
     gint64 range_start = target->target->byterangestart;
     gint64 range_end = target->target->byterangeend;
 
+    /* libcurl docs tell us size is always 1, but don't bet on it */
+    size_t all;
+    ssize_t r;
+    ssize_t written;
+    /*
+     * We write up to 32MB at a time, mainly to ensure that the below loops
+     * never bitrot, and it's regularly tested with real world RPMs.
+     */
+    #define WRITECB_CHUNK_MAX 32*1024*1024
+    /*
+     * The libcurl docs point to size always being 1, and the max value for
+     * nmemb being CURL_MAX_WRITE_SIZE (default 16kb, compile time setting),
+     * and if CURLOPT_HEADER is set, then it's CURL_MAX_HTTP_HEADER, usually
+     * meaning 100k.
+     */
+    all = size * nmemb;
+    written = 0;
+    if ((size != 0 && all / size != nmemb) || all > SSIZE_MAX) {
+        /*
+	 * But if libcurl changes (likely breaking the world), let's handle the
+	 * overflow by just writing one chunk at a time until we're done.
+	 */
+        all = WRITECB_CHUNK_MAX;
+    }
+
     if (range_start <= 0 && range_end <= 0) {
-        // Write everything curl give to you
-        target->writecb_recieved += all;
-        return fwrite(ptr, size, nmemb, target->f);
+        while(( all - written ) > 0) {
+	    r = write(target->fd, ptr + written, ((all - written) > WRITECB_CHUNK_MAX)? WRITECB_CHUNK_MAX : all - written);
+	    if (r < 0 && errno != EINTR) {
+	        g_warning("Error while writing file: %s", g_strerror(errno));
+		return (size_t)written;
+	    }
+	    written += r;
+	    target->writecb_recieved += r;
+	}
+        return (size_t)written;
     }
 
     /* Deal with situation when user wants only specific byte range of the
@@ -638,8 +667,6 @@ lr_writecb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
     gint64 cur_range_start = target->writecb_recieved;
     gint64 cur_range_end = cur_range_start + all;
-
-    target->writecb_recieved += all;
 
     if (target->target->byterangestart > 0) {
         // If byterangestart is specified, then CURLOPT_RESUME_FROM_LARGE
@@ -694,13 +721,25 @@ lr_writecb(char *ptr, size_t size, size_t nmemb, void *userdata)
     }
 
     assert(nmemb > 0);
-    cur_written = fwrite(ptr, size, nmemb, target->f);
-    if (cur_written != nmemb) {
-        g_warning("Error while writing file: %s", g_strerror(errno));
-        return 0; // There was an error
+    all = size * nmemb;
+    written = 0;
+    if ((size != 0 && all / size != nmemb) || all > SSIZE_MAX) {
+        /*
+	 * But if libcurl changes (likely breaking the world), let's handle the
+	 * overflow by just writing one chunk at a time until we're done.
+	 */
+        all = WRITECB_CHUNK_MAX;
     }
-
-    return cur_written_expected;
+    while(( all - written ) > 0) {
+        r = write(target->fd, ptr + written, ((all - written) > WRITECB_CHUNK_MAX)? WRITECB_CHUNK_MAX : all - written);
+	if (r < 0 && errno != EINTR) {
+	    g_warning("Error while writing file: %s", g_strerror(errno));
+	    return (size_t)written;
+	}
+	written += r;
+	target->writecb_recieved += r;
+    }
+    return (size_t)written;
 }
 
 /** Select a suitable mirror
@@ -1045,9 +1084,9 @@ remove_librepo_xattr(LrDownloadTarget * target)
 gboolean
 lr_zck_clear_header(LrTarget *target, GError **err)
 {
-    assert(target && target->f && target->target && target->target->path);
+    assert(target && target->fd >= 0 && target->target && target->target->path);
 
-    int fd = fileno(target->f);
+    int fd = target->fd;
     lseek(fd, 0, SEEK_END);
     if(ftruncate(fd, 0) < 0) {
         g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
@@ -1063,7 +1102,7 @@ find_local_zck_header(LrTarget *target, GError **err)
 {
     zckCtx *zck = NULL;
     gboolean found = FALSE;
-    int fd = fileno(target->f);
+    int fd = target->fd;
 
     if(target->target->handle->cachedir) {
         g_debug("%s: Cache directory: %s\n", __func__,
@@ -1142,7 +1181,7 @@ static gboolean
 prep_zck_header(LrTarget *target, GError **err)
 {
     zckCtx *zck = NULL;
-    int fd = fileno(target->f);
+    int fd = target->fd;
     GError *tmp_err = NULL;
 
     if(lr_zck_valid_header(target->target, target->target->path, fd,
@@ -1202,7 +1241,7 @@ find_local_zck_chunks(LrTarget *target, GError **err)
     assert(target && target->target && target->target->zck_dl);
 
     zckCtx *zck = zck_dl_get_zck(target->target->zck_dl);
-    int fd = fileno(target->f);
+    int fd = target->fd;
     if(zck && fd != zck_get_fd(zck) && !zck_set_fd(zck, fd)) {
         g_set_error(err, LR_DOWNLOADER_ERROR, LRE_ZCK,
                     "Unable to set zchunk file descriptor for %s: %s",
@@ -1271,7 +1310,7 @@ static gboolean
 prep_zck_body(LrTarget *target, GError **err)
 {
     zckCtx *zck = zck_dl_get_zck(target->target->zck_dl);
-    int fd = fileno(target->f);
+    int fd = target->fd;
     if(zck && fd != zck_get_fd(zck) && !zck_set_fd(zck, fd)) {
         g_set_error(err, LR_DOWNLOADER_ERROR, LRE_ZCK,
                     "Unable to set zchunk file descriptor for %s: %s",
@@ -1311,7 +1350,7 @@ static gboolean
 check_zck(LrTarget *target, GError **err)
 {
     assert(!err || *err == NULL);
-    assert(target && target->f && target->target);
+    assert(target && target->fd >= 0 && target->target);
 
     if(target->mirror->max_ranges == 0 || target->mirror->mirror->protocol != LR_PROTOCOL_HTTP) {
         target->zck_state = LR_ZCK_DL_BODY;
@@ -1403,11 +1442,10 @@ check_zck(LrTarget *target, GError **err)
 
 /** Open the file to write to
  */
-static FILE*
+static int
 open_target_file(LrTarget *target, GError **err)
 {
     int fd;
-    FILE *f;
 
     if (target->target->fd != -1) {
         // Use supplied filedescriptor
@@ -1416,7 +1454,7 @@ open_target_file(LrTarget *target, GError **err)
             g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
                         "dup(%d) failed: %s",
                         target->target->fd, g_strerror(errno));
-           return NULL;
+           return -1;
         }
     } else {
         // Use supplied filename
@@ -1429,20 +1467,11 @@ open_target_file(LrTarget *target, GError **err)
             g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
                         "Cannot open %s: %s",
                         target->target->fn, g_strerror(errno));
-            return NULL;
+            return -1;
         }
     }
 
-    f = fdopen(fd, "w+b");
-    if (!f) {
-        close(fd);
-        g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
-                    "fdopen(%d) failed: %s",
-                    fd, g_strerror(errno));
-        return NULL;
-    }
-
-    return f;
+    return fd;
 }
 
 /** Prepare next transfer
@@ -1523,8 +1552,8 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
     }
 
     // Prepare FILE
-    target->f = open_target_file(target, err);
-    if (!target->f)
+    target->fd = open_target_file(target, err);
+    if (target->fd < 0)
         goto fail;
     target->writecb_recieved = 0;
     target->writecb_required_range_written = FALSE;
@@ -1561,15 +1590,15 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
             target->curl_handle = NULL;
             g_free(target->headercb_interrupt_reason);
             target->headercb_interrupt_reason = NULL;
-            fclose(target->f);
-            target->f = NULL;
+            close(target->fd);
+            target->fd = -1;
             lr_downloadtarget_set_error(target->target, LRE_OK, NULL);
             return prepare_next_transfer(dd, candidatefound, err);
         }
     }
     # endif /* WITH_ZCHUNK */
 
-    int fd = fileno(target->f);
+    int fd = target->fd;
 
     if (target->resume && target->resume_count >= LR_DOWNLOADER_MAXIMAL_RESUME_COUNT) {
         target->resume = FALSE;
@@ -1581,8 +1610,7 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
     if (target->resume) {
         if (target->original_offset == -1) {
             // Determine offset
-            fseek(target->f, 0L, SEEK_END);
-            gint64 determined_offset = ftell(target->f);
+            off_t determined_offset = lseek(target->fd, 0L, SEEK_END);
             if (determined_offset == -1) {
                 // An error while determining offset =>
                 // Download the whole file again
@@ -1723,9 +1751,9 @@ fail:
         curl_easy_cleanup(target->curl_handle);
         target->curl_handle = NULL;
     }
-    if (target->f != NULL) {
-        fclose(target->f);
-        target->f = NULL;
+    if (target->fd != -1) {
+        close(target->fd);
+        target->fd = -1;
     }
 
     return FALSE;
@@ -2298,8 +2326,7 @@ check_transfer_statuses(LrDownload *dd, GError **err)
         //
         // Checksum checking
         //
-        fflush(target->f);
-        fd = fileno(target->f);
+        fd = target->fd;
 
         // Preserve timestamp of downloaded file if requested
         if (target->target->handle && target->target->handle->preservetime) {
@@ -2389,8 +2416,8 @@ transfer_error:
         target->curl_handle = NULL;
         g_free(target->headercb_interrupt_reason);
         target->headercb_interrupt_reason = NULL;
-        fclose(target->f);
-        target->f = NULL;
+        close(target->fd);
+        target->fd = -1;
         if (target->curl_rqheaders) {
             curl_slist_free_all(target->curl_rqheaders);
             target->curl_rqheaders = NULL;
@@ -2778,6 +2805,7 @@ lr_download(GSList *targets,
         target->target->rcode   = LRE_UNFINISHED;
         target->target->err     = "Not finished";
         target->handle          = dtarget->handle;
+        target->fd              = -1;
         dd.targets = g_slist_append(dd.targets, target);
         // Add list of handle internal mirrors to dd.handle_mirrors
         // if doesn't exists yet and set the list reference
@@ -2809,8 +2837,8 @@ lr_download_cleanup:
             curl_multi_remove_handle(dd.multi_handle, target->curl_handle);
             curl_easy_cleanup(target->curl_handle);
             target->curl_handle = NULL;
-            fclose(target->f);
-            target->f = NULL;
+            close(target->fd);
+            target->fd = -1;
             g_free(target->headercb_interrupt_reason);
             target->headercb_interrupt_reason = NULL;
 
@@ -2856,7 +2884,7 @@ lr_download_cleanup:
     for (GSList *elem = dd.targets; elem; elem = g_slist_next(elem)) {
         LrTarget *target = elem->data;
         assert(target->curl_handle == NULL);
-        assert(target->f == NULL);
+        assert(target->fd == -1);
 
         // Remove file created for the target if download was
         // unsuccessful and the file doesn't exists before or


### PR DESCRIPTION
the FILE related IO functions in libc do buffering inside the C library, and are generally less performant than using the file descriptor based open()/read()/write() functions.

The FILE based approach somewhat limits the maximum throughput of librepo, as well as increases CPU usage. In my benchmarks of a reposync of the Amazon Linux 2023 x86-64 repositories, this move to file descriptor based IO saves about 1 second of user time, and .5 seconds of system time, for a wall clock time benefit of a few seconds (102s vs 99s).