### PR TITLE
Increase checksum buffer to 128kb, improving download performance.

### DIFF
--- a/librepo/checksum.c
+++ b/librepo/checksum.c
@@ -37,7 +37,7 @@
 #include "util.h"
 #include "xattr_internal.h"
 
-#define BUFFER_SIZE             2048
+#define BUFFER_SIZE             128*1024
 #define MAX_CHECKSUM_NAME_LEN   7
 
 LrChecksumType


### PR DESCRIPTION
Reading 2kb at a time to compute the checksum limits network throughput. Bumping up to 128kb seems to give a good balance of memory usage and performance.

Benchmarks done on a m5n.16xlarge EC2 instance doing a reposync on the Amazon Linux 2023 x86-64 repositories showed that this change, when combined with the (smaller) benefits of my avoiding libc IO patch, reduce system CPU time by another half second, and cut a further 3 seconds off total time:

102s (original) -> 99 (no libc buffered io) -> 95s (this patch)