### PR TITLE
Don't fsync() in checksum

### DIFF
--- a/librepo/checksum.c
+++ b/librepo/checksum.c
@@ -266,17 +266,6 @@ lr_checksum_fd_compare(LrChecksumType type,
 
     *matches = (strcmp(expected, checksum)) ? FALSE : TRUE;
 
-    if (fsync(fd) != 0) {
-        if (errno == EROFS || errno == EINVAL) {
-            g_debug("fsync failed: %s", strerror(errno));
-        } else {
-            g_set_error(err, LR_CHECKSUM_ERROR, LRE_FILE,
-                        "fsync failed: %s", strerror(errno));
-            lr_free(checksum);
-            return FALSE;
-        }
-    }
-
     if (caching && *matches && timestamp != -1) {
         // Store timestamp and checksum as extended file attribute if caching is enabled
         FSETXATTR(fd, timestamp_key, timestamp_str, strlen(timestamp_str), 0);


### PR DESCRIPTION
This gives a major boost in librepo performance. For a reposync of an Amazon Linux 2023 x86-64 repository on a m5n.16xlarge EC2 instance with a 500MB/sec 3000IOP EBS volume, this alone reduces run time by 30 seconds of wall time, and gets reposync nearly using a whole core rather than only two thirds of one.

---

For reference, my benchmarking has been done on a `m5n.16xlarge` EC2 instance to the in-region S3 buckets as well as to the CDN repositories. That instance type has 256GB memory, a 75Gbit network connection, and is a 64 core Cascade Lake system. The root volume is a 256GB gp3 EBS volume with 500MB/sec of IO and 3000 IOPs.

The background of this is that a *lot* of EC2 instances don't live that long (relatively speaking), and never install RPMs except on launch - so all the time-to-install RPMs is time spent scaling up a system that could be better served by running the customer workload.

Goes well when paired with https://github.com/rpm-software-management/librepo/pull/294 and https://github.com/rpm-software-management/librepo/pull/295 and https://github.com/rpm-software-management/librepo/pull/296

---

What I'm not entirely sure of here is the other implications of this change - as in, what is relying on this checksum being crash safe, and should we instead re-compute it sometimes?

I'm open to putting this behind an ifdef or something if that seems safer. I'd love input here.