### PR TITLE
Change header files to match a configured ABI regarding a zchunk support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,10 @@ IF (USE_RUN_GNUPG_USER_SOCKET)
 ENDIF (USE_RUN_GNUPG_USER_SOCKET)
 
 IF (WITH_ZCHUNK)
-PKG_CHECK_MODULES(ZCHUNKLIB zck>=0.9.11 REQUIRED)
-SET (CMAKE_C_FLAGS          "${CMAKE_C_FLAGS} -DWITH_ZCHUNK")
-SET (CMAKE_C_FLAGS_DEBUG    "${CMAKE_C_FLAGS_DEBUG} -DWITH_ZCHUNK")
+    PKG_CHECK_MODULES(ZCHUNKLIB zck>=0.9.11 REQUIRED)
+    SET (LIBREPO_ZCHUNK_ENABLED "1")
+ELSE (WITH_ZCHUNK)
+    SET (LIBREPO_ZCHUNK_ENABLED "0")
 ENDIF (WITH_ZCHUNK)
 
 INCLUDE_DIRECTORIES(${GLIB2_INCLUDE_DIRS})
@@ -91,6 +92,12 @@ IF (NOT CURL_FOUND)
     MESSAGE(FATAL_ERROR "No CURL library installed")
 ENDIF (NOT CURL_FOUND)
 
+# Generate header files with the configured ABI (e.g. with/without zchunk).
+
+configure_file("librepo/downloadtarget.h.in" "librepo/downloadtarget.h" @ONLY)
+configure_file("librepo/handle.h.in" "librepo/handle.h" @ONLY)
+configure_file("librepo/util.h.in" "librepo/util.h" @ONLY)
+INCLUDE_DIRECTORIES("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/librepo")
 
 # Add include dirs
 

--- a/doc/c/Doxyfile.in.in
+++ b/doc/c/Doxyfile.in.in
@@ -846,7 +846,7 @@ WARN_LOGFILE           =
 
 INPUT                  = @CMAKE_SOURCE_DIR@/librepo/checksum.h \
                          @CMAKE_SOURCE_DIR@/librepo/gpg.h \
-                         @CMAKE_SOURCE_DIR@/librepo/handle.h \
+                         @CMAKE_BINARY_DIR@/librepo/handle.h \
                          @CMAKE_SOURCE_DIR@/librepo/metalink.h \
                          @CMAKE_SOURCE_DIR@/librepo/librepo.h \
                          @CMAKE_SOURCE_DIR@/librepo/package_downloader.h \
@@ -856,7 +856,7 @@ INPUT                  = @CMAKE_SOURCE_DIR@/librepo/checksum.h \
                          @CMAKE_SOURCE_DIR@/librepo/result.h \
                          @CMAKE_SOURCE_DIR@/librepo/types.h \
                          @CMAKE_SOURCE_DIR@/librepo/url_substitution.h \
-                         @CMAKE_SOURCE_DIR@/librepo/util.h \
+                         @CMAKE_BINARY_DIR@/librepo/util.h \
                          @CMAKE_SOURCE_DIR@/librepo/version.h \
                          @CMAKE_SOURCE_DIR@/librepo/xmlparser.h \
                          @CMAKE_SOURCE_DIR@/librepo/yum.h

--- a/librepo.spec
+++ b/librepo.spec
@@ -66,6 +66,9 @@ metadata.
 %package devel
 Summary:        Repodata downloading library
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if %{with zchunk}
+Requires:       zchunk-devel%{?_isa}
+%endif
 
 %description devel
 Development files for librepo.

--- a/librepo/CMakeLists.txt
+++ b/librepo/CMakeLists.txt
@@ -30,7 +30,7 @@ LIST(APPEND librepo_HEADERS
     checksum.h
     fastestmirror.h
     gpg.h
-    handle.h
+    ${CMAKE_CURRENT_BINARY_DIR}/handle.h
     librepo.h
     metadata_downloader.h
     metalink.h
@@ -43,12 +43,12 @@ LIST(APPEND librepo_HEADERS
     result.h
     types.h
     url_substitution.h
-    util.h
+    ${CMAKE_CURRENT_BINARY_DIR}/util.h
     version.h
     xmlparser.h
     yum.h
     downloader.h
-    downloadtarget.h)
+    ${CMAKE_CURRENT_BINARY_DIR}/downloadtarget.h)
 
 LIST(APPEND librepo_internal_HEADERS
     downloader_internal.h

--- a/librepo/downloadtarget.h.in
+++ b/librepo/downloadtarget.h.in
@@ -23,9 +23,9 @@
 
 #include <glib.h>
 
-#ifdef WITH_ZCHUNK
+#if @LIBREPO_ZCHUNK_ENABLED@
 #include <zck.h>
-#endif /* WITH_ZCHUNK */
+#endif /* @LIBREPO_ZCHUNK_ENABLED@ */
 
 #include <librepo/handle.h>
 #include <librepo/rcodes.h>
@@ -150,7 +150,7 @@ typedef struct {
     char *range; /*!<
         Range string to download, overrides byterangestart and end */
 
-    #ifdef WITH_ZCHUNK
+    #if @LIBREPO_ZCHUNK_ENABLED@
     zckDL *zck_dl; /*!<
         Zchunk download context */
 
@@ -162,7 +162,7 @@ typedef struct {
 
     double downloaded; /*!<
         Amount already downloaded in zchunk file */
-    #endif /* WITH_ZCHUNK */
+    #endif /* @LIBREPO_ZCHUNK_ENABLED@ */
 
 } LrDownloadTarget;
 

--- a/librepo/handle.h.in
+++ b/librepo/handle.h.in
@@ -38,11 +38,11 @@ G_BEGIN_DECLS
  */
 typedef struct _LrHandle LrHandle;
 
-#ifdef WITH_ZCHUNK
+#if @LIBREPO_ZCHUNK_ENABLED@
 /** Define LRO_SUPPORTS_CACHEDIR so clients can check for this feature at build
  * time */
 #define LRO_SUPPORTS_CACHEDIR
-#endif /* WITH_ZCHUNK */
+#endif /* @LIBREPO_ZCHUNK_ENABLED@ */
 
 /** LRO_FASTESTMIRRORMAXAGE default value */
 #define LRO_FASTESTMIRRORMAXAGE_DEFAULT     2592000L // 30 days

--- a/librepo/util.h.in
+++ b/librepo/util.h.in
@@ -26,9 +26,9 @@
 #include <stdarg.h>
 #include <curl/curl.h>
 
-#ifdef WITH_ZCHUNK
+#if @LIBREPO_ZCHUNK_ENABLED@
 #include <zck.h>
-#endif /* WITH_ZCHUNK */
+#endif /* @LIBREPO_ZCHUNK_ENABLED@ */
 
 #include <librepo/checksum.h>
 #include <librepo/xmlparser.h>
@@ -205,7 +205,7 @@ lr_key_file_save_to_file(GKeyFile *key_file,
                          const gchar *filename,
                          GError **error);
 
-#ifdef WITH_ZCHUNK
+#if @LIBREPO_ZCHUNK_ENABLED@
 /** Get LrChecksumType that corresponds to zck_hash
  * @param zck_checksum_type  zck_hash value
  * @return checksum_type     corresponding LrChecksumType value
@@ -286,7 +286,7 @@ lr_zck_valid_header(LrDownloadTarget *target, char *filename, int fd, GError **e
  * Return value will be NULL if no files match or there's an error.
  * err will be set if there's an error
  */
-#endif /* WITH_ZCHUNK */
+#endif /* @LIBREPO_ZCHUNK_ENABLED@ */
 
 GSList *
 lr_get_recursive_files(char *path, char *extension, GError **err);


### PR DESCRIPTION
If librepo was built with -DWITH_ZCHUNK=ON but an application included <librepo/librepo.h> without defining -DWITH_ZCHUNK, struct LrDownloadTarget mismatched. The same problem happened vice versa. Following the correct ABI was a burden for librepo applications and a mistake there could lead to a memory corruption.

This patch replaces the WITH_ZCHUNK macros in the public header files with a constant so that the installed header files do not depend on the macro and always match the installed library.

This patch also adds a missing RPM dependency on zchunk-devel to librepo-devel if built with enabled zchunk. (Some header files include <zck.h>.)

An implementation note: CMakeLists.txt appends the header search paths with both a top-level build directory as well as with a librepo subdirectory. The latter is for "util.h" inclusions from the C files, the former is for <librepo/util.h> inclusions from other librepo header files. Without the former a C preprocesor would use already installed <librepo/util.h>. We do not want to infect the being built library with old and possible nonmatching system header files.

Fixes: #298