### PR TITLE
gpg_gpgme.c: fix build errors with older gcc

### DIFF
--- a/librepo/gpg_gpgme.c
+++ b/librepo/gpg_gpgme.c
@@ -144,6 +144,7 @@ exit:
     }
     freecon(old_default_context);
 #endif
+    return;
 }
 
 static gpgme_ctx_t


### PR DESCRIPTION
When selinux is not enabled, older gcc versions error out this way:

```
| /home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/hosttools/gcc -DG_LOG_DOMAIN=\"librepo\" -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -Dlibrepo_EXPORTS -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/git -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include/libmount -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include/blkid -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include/glib-2.0 -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/lib/glib-2.0/include -I/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include/libxml2 -isystem/home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/recipe-sysroot-native/usr/include -O2 -pipe -std=c99 -Wall -fPIC -MD -MT librepo/CMakeFiles/librepo.dir/gpg_gpgme.c.o -MF librepo/CMakeFiles/librepo.dir/gpg_gpgme.c.o.d -o librepo/CMakeFiles/librepo.dir/gpg_gpgme.c.o -c /home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/git/librepo/gpg_gpgme.c 
| /home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/git/librepo/gpg_gpgme.c: In function ‘lr_gpg_ensure_socket_dir_exists’: 
| /home/pokybuild/yocto-worker/oe-selftest-armhost/build/build-st-1938845/tmp-mc-tiny/work/aarch64-linux/librepo-native/1.17.0/git/librepo/gpg_gpgme.c:135:1: error: label at end of compound statement
|   135 | exit:
|       | ^~~~
```
Ensuring the exit: block is not empty fixes the issue.