### PR TITLE
Fix some compiler warnings

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -379,7 +379,7 @@ lr_prepare_lrmirrors(GSList *list, LrTarget *target)
     GSList *lrmirrors = NULL;
 
     if (handle && handle->internal_mirrorlist) {
-        g_debug("%s: Preparing internal mirror list for handle id: %p", __func__, handle);
+        g_debug("%s: Preparing internal mirror list for handle id: %p", __func__, (void*)handle);
         for (GSList *elem = handle->internal_mirrorlist;
              elem;
              elem = g_slist_next(elem))
@@ -2189,7 +2189,7 @@ sort_mirrors(GSList *mirrors, LrMirror *mirror, gboolean success, gboolean serio
 exit:
     if (g_getenv("LIBREPO_DEBUG_ADAPTIVEMIRRORSORTING")) {
         // Debug
-        g_debug("%s: Updated order of mirrors (for %p):", __func__, mirrors);
+        g_debug("%s: Updated order of mirrors (for %p):", __func__, (void*)mirrors);
         for (GSList *elem = mirrors; elem; elem = g_slist_next(elem)) {
             LrMirror *m = elem->data;
             g_debug(" %s (s: %d f: %d)", m->mirror->url,

--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -20,6 +20,7 @@
 
 #define _POSIX_C_SOURCE 200809L
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <glib.h>
 #include <errno.h>

--- a/librepo/types.h
+++ b/librepo/types.h
@@ -74,7 +74,7 @@ typedef enum {
     LR_AUTH_NTLM        = (1<<3),  /*!< HTTP NTLM authentication */
     LR_AUTH_DIGEST_IE   = (1<<4),  /*!< HTTP Digest authentication with an IE flavor */
     LR_AUTH_NTLM_WB     = (1<<5),  /*!< NTLM delegating to winbind helper */
-    LR_AUTH_ONLY        = (1<<31), /*!< This is a meta symbol. OR this value
+    LR_AUTH_ONLY        = ((int)(1u<<31)), /*!< This is a meta symbol. OR this value
                                         together with a single specific auth
                                         value to force libcurl to probe for
                                         un-restricted auth and if not, only

--- a/librepo/xmlparser.c
+++ b/librepo/xmlparser.c
@@ -174,7 +174,7 @@ lr_xml_parser_generic(XmlParser *parser,
         }
 
         if (xmlParseChunk(ctxt, buf, len, len == 0)) {
-            xmlErrorPtr error = xmlCtxtGetLastError(ctxt);
+            const xmlError *error = xmlCtxtGetLastError(ctxt);
             ret = FALSE;
 
             g_debug("%s: Parse error at line: %d (%s)",


### PR DESCRIPTION
This patch set resolves these compiler warnings:

* enumerator value for ‘LR_AUTH_ONLY’ is not an integer constant expression
* format ‘%p’ expects argument of type ‘void *’
* initialization discards ‘const’ qualifier from pointer target type
* _BSD_SOURCE and _SVID_SOURCE are deprecated

Warnings regarding new python and new curl will be addressed in separate pull requests as they will probably need to implement fallback code for older libraries.