### PR TITLE
Use rpm-sequoia on RHEL 10+

### DIFF
--- a/librepo.spec
+++ b/librepo.spec
@@ -8,7 +8,7 @@
 %bcond_without zchunk
 %endif
 
-%if 0%{?fedora} >= 39
+%if 0%{?fedora} >= 39 || 0%{?rhel} >= 10
 %bcond_with use_gpgme
 %bcond_with use_selinux
 %else


### PR DESCRIPTION
RHEL 10 also has a sufficiently new RPM with rpm-sequoia enabled.

This avoids test failures in ELN, e.g. https://koji.fedoraproject.org/koji/taskinfo?taskID=120187681 with gpgme vs https://koji.fedoraproject.org/koji/taskinfo?taskID=120191938 with rpm-sequoia (this patch).