### PR TITLE
tests: Adapt to CURL without NTLM support

### DIFF
--- a/tests/python/tests/test_handle.py
+++ b/tests/python/tests/test_handle.py
@@ -474,14 +474,22 @@ class TestCaseHandle(unittest.TestCase):
         self.assertEqual(h.httpheader, None)
 
         self.assertEqual(h.httpauthmethods, librepo.LR_AUTH_BASIC)
-        h.httpauthmethods = librepo.LR_AUTH_NTLM
-        self.assertEqual(h.httpauthmethods, librepo.LR_AUTH_NTLM)
+        try:
+            h.httpauthmethods = librepo.LR_AUTH_NTLM
+        except librepo.LibrepoException as exception:
+            if not "not found built-in" in str(exception):
+                raise exception
+            self.assertEqual(h.httpauthmethods, librepo.LR_AUTH_NTLM)
         h.httpauthmethods = None
         self.assertEqual(h.httpauthmethods, librepo.LR_AUTH_BASIC)
 
         self.assertEqual(h.proxyauthmethods, librepo.LR_AUTH_BASIC)
-        h.proxyauthmethods = librepo.LR_AUTH_NTLM
-        self.assertEqual(h.proxyauthmethods, librepo.LR_AUTH_NTLM)
+        try:
+            h.proxyauthmethods = librepo.LR_AUTH_NTLM
+        except librepo.LibrepoException as exception:
+            if not "not found built-in" in str(exception):
+                raise exception
+            self.assertEqual(h.proxyauthmethods, librepo.LR_AUTH_NTLM)
         h.proxyauthmethods = None
         self.assertEqual(h.proxyauthmethods, librepo.LR_AUTH_BASIC)
 

--- a/tests/test_handle.c
+++ b/tests/test_handle.c
@@ -58,7 +58,7 @@ START_TEST(test_handle)
     ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTCERT, "/etc/proxy_cert.pem"));
     ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCLIENTKEY, "/etc/proxy_cert.key"));
     ck_assert(lr_handle_setopt(h, NULL, LRO_PROXY_SSLCACERT, "/etc/proxy_ca.pem"));
-    ck_assert(lr_handle_setopt(h, NULL, LRO_HTTPAUTHMETHODS, LR_AUTH_NTLM));
+    (void)lr_handle_setopt(h, NULL, LRO_HTTPAUTHMETHODS, LR_AUTH_NTLM);
     ck_assert(lr_handle_setopt(h, NULL, LRO_PROXYAUTHMETHODS, LR_AUTH_DIGEST));
     lr_handle_free(h);
 }


### PR DESCRIPTION
If CURL is built without NTLM support (e.g. if libcurl-minimal RPM package is installed instead of libcurl on Fedora), tests/test_handle.c failed:

    /home/test/librepo/tests/test_handle.c:61:F:Main:test_handle:0: Assertion 'lr_handle_setopt(h, ((void *)0), LRO_HTTPAUTHMETHODS, LR_AUTH_NTLM)' failed

The cause is that the test exhibing NTLM authentication also checks that lr_handle_setopt() succeeds.

This patch stops checking a return value of lr_handle_setopt() in case of LR_AUTH_NTLM because a meaning of the test is checking for memory leaks.