### PR TITLE
Introduce entropy for fastestmirror option

### DIFF
--- a/librepo/fastestmirror.c
+++ b/librepo/fastestmirror.c
@@ -702,12 +702,16 @@ lr_fastestmirror(LrHandle *handle,
     //
     // Instead of using a strict sorted list, shuffle all mirrors with lower latency than 2x
     // the best mirror, to introduce enough entropy to spread the load across nearby mirrors.
-    double bestMirrorLatency = ((LrFastestMirror *)lrfastestmirrors->data)->plain_connect_time;
+    double bestMirrorLatency = 0;
+    if (lrfastestmirrors != NULL) {
+        bestMirrorLatency = ((LrFastestMirror *)lrfastestmirrors->data)->plain_connect_time;
+    }
 
     for (GSList *elem = lrfastestmirrors; elem; elem = g_slist_next(elem)) {
         LrFastestMirror *mirror = elem->data;
         g_debug("%s: %3.6f : %s", __func__, mirror->plain_connect_time, mirror->url);
-        if (mirror->plain_connect_time < (2.0 * bestMirrorLatency) ) { // Shuffle nearby mirrors
+        if (mirror->plain_connect_time >= 0 &&
+            mirror->plain_connect_time < (2.0 * bestMirrorLatency)) { // Shuffle nearby mirrors
             new_list = g_slist_insert(new_list, mirror->url, g_random_int_range(0, g_slist_length(new_list)+1));
         } else { // Far away mirrors appended as backup options
             new_list = g_slist_append(new_list, mirror->url);


### PR DESCRIPTION
Howdy,

I do want to caveat this PR with the fact that this is the first time I've touched the librepo codebase, and I haven't gotten the test suite running on my local dev box (didn't attempt to after moderate issues just getting the library to build) so I have not run this through all the unit tests. If any of the unit tests expect fastestmirror to always return a stable list of mirrors, that test will break. I didn't see any test definitions that looked to be testing this in a cursory review... I did build and test this change locally on my Alma9 box.

Traditionally the fastestmirror option has relied on taking the provided mirrorlist from the repo CDN and measured the latency to each mirror by timing the libCurl socket open time. This has resulted in several undesirable properties for the fastestmirror option:

1. Socket open latency is not always a good proxy for download bandwidth performance, so if the nearest mirror to a user happens to be particularly slow, they will always experience a very slow download despite having fastestmirror enabled.
2. Mirror operators don't appreciate fastestmirror being used by high density deployments (i.e. data centers) where thousands to millions of hosts with fastestmirror enabled all dogpile the single lowest latency mirror despite there being several mirrors within almost as close proximity to the site

This change introduces entropy into the mirror selection process by taking all mirrors with latency measurements less than twice that of the nearest mirror and shuffling those mirrors evenly, then simply appending all other mirrors to the end of the list in strict latency order.

I selected 2x as the upper cutoff for shuffling in mirrors based on nothing analytical. I expect that 2x would do a good job of including all mirrors in the same metro if there's other nearby mirrors since the latency is likely dominated by last mile connectivity. For other users who are already seeing significant >100ms latency to the best mirror, picking <200ms mirrors is going to possibly be noticeably worse, but users 100ms away from the closest mirror are going to be having a poor user experience regardless of which mirror they select.