### PR TITLE
Fix input termination for `pgpParsePkts`

### DIFF
--- a/librepo/gpg_rpm.c
+++ b/librepo/gpg_rpm.c
@@ -350,7 +350,7 @@ lr_gpg_import_key_from_memory(const char *key, size_t key_len, const char *home_
 
     // `pgpParsePkts` needs null-terminated input, if null byte not found, make a local null-terminated copy
     g_autofree gchar * key_with_null_byte = NULL;
-    if (memchr(block_begin, '\0', key_len) == NULL) {
+    if (memchr(block_begin, '\0', key_len - (block_begin - key)) == NULL) {
         key_with_null_byte = g_new(gchar, key_len + 1);
         memcpy(key_with_null_byte, key, key_len);
         key_with_null_byte[key_len] = '\0';
@@ -533,7 +533,7 @@ check_signature(const gchar * sig_buf, ssize_t sig_buf_len, const gchar * data, 
 
         // `pgpParsePkts` needs null-terminated input, if null byte not found, make a local null-terminated copy
         g_autofree gchar * sig_buf_with_null_byte = NULL;
-        if (memchr(block_begin, '\0', sig_buf_len) == NULL) {
+        if (memchr(block_begin, '\0', sig_buf_len - (block_begin - sig_buf)) == NULL) {
             sig_buf_with_null_byte = g_new(gchar, sig_buf_len + 1);
             memcpy(sig_buf_with_null_byte, sig_buf, sig_buf_len);
             sig_buf_with_null_byte[sig_buf_len] = '\0';


### PR DESCRIPTION
The `pgpParsePkts` function needs the OpenPGP ASCII armored input to be null terminated. The librepo contains code that checks if the input is null-terminated. If it is not, the code creates a local null-terminated copy of the input.

There was a bug in the code, so it may look for a terminating null several bytes behind the input buffer. And when a null was found behind the input buffer, the termination was not done. This caused the `pgpParsePkts` function to process several extra characters after the input buffer. These characters are generally random and sometimes cause the `pgpParsePkts` function to return an error.

I hope this fixes https://github.com/rpm-software-management/dnf/issues/2107