### PR TITLE
test_yum_package_downloading.py: Don't hardcode a value for EOPNOTSUPP

### DIFF
--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -6,6 +6,7 @@ import hashlib
 import unittest
 import tempfile
 import xattr
+import errno
 
 import tests.servermock.yum_mock.config as config
 
@@ -758,7 +759,7 @@ class TestCaseYumPackagesDownloading(TestCaseWithServer):
                            "user.librepo.downloadinprogress".encode("utf-8"),
                            "".encode("utf-8"))
         except IOError as err:
-            if err.errno == 95:
+            if err.errno == errno.EOPNOTSUPP:
                 self.skipTest('extended attributes are not supported')
             raise
 


### PR DESCRIPTION
For historical reasons, errno numbers are not the same on all architectures (compatibility with other operating systems already available on the same hardware was considered more important than having the same numbers on all Linux architectures).