### PR TITLE
Enable automatic PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Assign everything by default to the dnf-team
+* @rpm-software-management/dnf-team


### PR DESCRIPTION
Create a global rule to auto-assign all PR reviews to the dnf team, which will then handle them in a round-robin fashion based on GitHub settings.