### PR TITLE
cmake: doxygen is required for the "doc" target

### DIFF
--- a/doc/c/CMakeLists.txt
+++ b/doc/c/CMakeLists.txt
@@ -1,7 +1,5 @@
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-    CONFIGURE_FILE("Doxyfile.in.in" "${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in" @ONLY)
-    add_custom_target(doc-c
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-        COMMENT "Building C API documentation with Doxygen" VERBATIM)
-endif(DOXYGEN_FOUND)
+find_package(Doxygen REQUIRED)
+CONFIGURE_FILE("Doxyfile.in.in" "${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in" @ONLY)
+add_custom_target(doc-c
+    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+    COMMENT "Building C API documentation with Doxygen" VERBATIM)


### PR DESCRIPTION
Currently, CMake ends with a somewhat cryptic error:

CMake Error at doc/CMakeLists.txt:5 (ADD_DEPENDENCIES):
  The dependency target "doc-c" of target "doc" does not exist.

This occurs if Doxygen is not installed and ENABLE_DOCS is set to ON
(which is the default).

With this change, a clearer error message is printed:

Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)

Thanks to @mcrha for reporting the issue and suggesting the fix.