### PR TITLE
Propagate return value from `prepare_repo_download_targets`

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -1051,7 +1051,12 @@ lr_yum_download_repo(LrHandle *handle,
 
     assert(!err || *err == NULL);
 
-    prepare_repo_download_targets(handle, repo, repomd, NULL, &targets, &cbdata_list, err);
+    ret = prepare_repo_download_targets(handle, repo, repomd, NULL, &targets, &cbdata_list, err);
+    if (!ret) {
+        assert(!err || *err != NULL);
+        return ret;
+    }
+    assert(!err || *err == NULL);
 
     if (!targets)
         return TRUE;


### PR DESCRIPTION
It also ensures that when return value is false there is some error set. This is a common pattern in the librepo code.

For: https://github.com/rpm-software-management/librepo/issues/340