### PR TITLE
Use 0 instead of `false` for assert

### DIFF
--- a/librepo/metadata_downloader.c
+++ b/librepo/metadata_downloader.c
@@ -535,7 +535,7 @@ propagate_metalink_or_mirrorlist_download_targets(GSList *download_targets, GErr
             target->handle->mirrorlist_fd = download_target->fd;
         } else {
             // The targets should download only metalinks or mirrorlists
-            assert(false);
+            assert(0);
         }
 
         if (lseek(download_target->fd, 0, SEEK_SET) != 0) {


### PR DESCRIPTION
`false` is not always defined.
For example centos builds fail because it is undeclared, example from dnf-nightly: https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/centos-stream-9-x86_64/09163951-librepo/builder-live.log.gz

To fix this we could also include <stdbool.h> but this is simpler and its already used in couple places.