### PR TITLE
test: Use 1 instead of true

### DIFF
--- a/examples/c/download_repos_parallel.c
+++ b/examples/c/download_repos_parallel.c
@@ -49,13 +49,13 @@ LrHandle *create_handle(const char *repo) {
 
   // --- Optional arguments --------------------------------------------
   // Make download interruptible
-  lr_handle_setopt(h, NULL, LRO_INTERRUPTIBLE, true);
+  lr_handle_setopt(h, NULL, LRO_INTERRUPTIBLE, 1);
   // Destination directory for metadata
   gchar *repo_destdir = g_strconcat(DESTDIR, "/", repo, NULL);
   lr_handle_setopt(h, NULL, LRO_DESTDIR, repo_destdir);
   g_free(repo_destdir);
   // Check checksum of all files (if checksum is available in repomd.xml)
-  lr_handle_setopt(h, NULL, LRO_CHECKSUM, true);
+  lr_handle_setopt(h, NULL, LRO_CHECKSUM, 1);
   // Download only primary.xml, comps.xml and updateinfo
   // Note: repomd.xml is downloaded implicitly!
   // Note: If LRO_YUMDLIST is None -> all files are downloaded


### PR DESCRIPTION
Building in RHEL 10.0 failed:

    /home/test/librepo/examples/c/download_repos_parallel.c: In function ‘create_handle’:
    /home/test/librepo/examples/c/download_repos_parallel.c:52:48: error: ‘true’ undeclared (first use in this function)
       52 |   lr_handle_setopt(h, NULL, LRO_INTERRUPTIBLE, true);
          |                                                ^~~~

true is not implicitly defined until ISO C23.

This patch fixes it by using a numerical value, similar to commit 0dae97aafc4d0112cc192dd6c9b74687342431f5 ("Use 0 instead of `false` for assert").