### PR TITLE
rhel-9.7: Propagate return value from `prepare_repo_download_targets`

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -961,7 +961,12 @@ lr_yum_download_repo(LrHandle *handle,
 
     assert(!err || *err == NULL);
 
-    prepare_repo_download_targets(handle, repo, repomd, NULL, &targets, &cbdata_list, err);
+    ret = prepare_repo_download_targets(handle, repo, repomd, NULL, &targets, &cbdata_list, err);
+    if (!ret) {
+        assert(!err || *err != NULL);
+        return ret;
+    }
+    assert(!err || *err == NULL);
 
     if (!targets)
         return TRUE;


### PR DESCRIPTION
Backport: https://github.com/rpm-software-management/librepo/pull/341