### PR TITLE
CI: Correct a link to packit documentation

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,5 @@
 # See the documentation for more information:
-# https://packit.dev/docs/configuration/
+# https://packit.dev/docs/configuration
 
 specfile_path: librepo.spec
 


### PR DESCRIPTION
The previous link returned 404 HTTP error.