### PR TITLE
Merge packit copr_build jobs into one

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,10 +15,6 @@ jobs:
     targets:
       - epel-9
       - epel-10
-
-  - job: copr_build
-    trigger: pull_request
-    targets:
       - fedora-all
 
   - job: tests


### PR DESCRIPTION
To bypass issue with "No build defined for the target...". See
https://github.com/packit/packit-service/issues/2859 for details.