### PR TITLE
Do not fail in lr_prepare_repodata_dir() if repodata/ dir exists

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -326,7 +326,7 @@ lr_prepare_repodata_dir(LrHandle *handle,
     if (create_repodata_dir) {
         /* Prepare repodata/ subdir */
         rc = mkdir(path_to_repodata, S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH);
-        if (rc == -1) {
+        if (rc == -1 && errno != EEXIST) {
             g_debug("%s: Cannot create dir: %s (%s)",
                     __func__, path_to_repodata, g_strerror(errno));
             g_set_error(err, LR_YUM_ERROR, LRE_CANNOTCREATEDIR,


### PR DESCRIPTION
If mkdir() fails and errno is EEXIST, that's ok.  It means we already have the repodata/ directory.  Just keep going.  But any other errors get reported and the function fails.

Fixing this fixes the problem I've been seeing on my system ever since moving to dnf5, which is:

    $ sudo dnf check-update
    # ERROR: something about directory already existing
    # argh..., so then do
    $ sudo dnf clean all
    $ sudo dnf check-update

Now I can just do 'sudo dnf check-update' and it works.  I am seeing this on Fedora 42 right now, but I also saw it on previous releases.