### PR TITLE
Replace deprecated CURLOPT_PROGRESSFUNCTION

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -417,10 +417,10 @@ lr_prepare_lrmirrors(GSList *list, LrTarget *target)
  */
 static int
 lr_progresscb(void *ptr,
-              double total_to_download,
-              double now_downloaded,
-              G_GNUC_UNUSED double total_to_upload,
-              G_GNUC_UNUSED double now_uploaded)
+              curl_off_t total_to_download,
+              curl_off_t now_downloaded,
+              G_GNUC_UNUSED curl_off_t total_to_upload,
+              G_GNUC_UNUSED curl_off_t now_uploaded)
 {
     int ret = LR_CB_OK;
     LrTarget *target = ptr;
@@ -1631,9 +1631,9 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
     // Prepare progress callback
     target->cb_return_code = LR_CB_OK;
     if (target->target->progresscb) {
-        c_rc = curl_easy_setopt(h, CURLOPT_PROGRESSFUNCTION, lr_progresscb) ||
+        c_rc = curl_easy_setopt(h, CURLOPT_XFERINFOFUNCTION, lr_progresscb) ||
                curl_easy_setopt(h, CURLOPT_NOPROGRESS, 0) ||
-               curl_easy_setopt(h, CURLOPT_PROGRESSDATA, target);
+               curl_easy_setopt(h, CURLOPT_XFERINFODATA, target);
         assert(c_rc == CURLE_OK);
     }
 


### PR DESCRIPTION
When building with curl 7.32.0 or newer a deprecation warning was produced:

    /home/test/librepo/librepo/downloader.c: In function ‘prepare_next_transfer’:
    /home/test/librepo/librepo/downloader.c:1634:9: warning: ‘CURLOPT_PROGRESSFUNCTION’ is deprecated: since 7.32.0. Use CURLOPT_XFERINFOFUNCTION [-Wdeprecated-declarations]
     1634 |         c_rc = curl_easy_setopt(h, CURLOPT_PROGRESSFUNCTION, lr_progresscb) ||
	  |         ^~~~
    In file included from /home/test/librepo/librepo/downloader.c:37:
    /usr/include/curl/curl.h:1333:3: note: declared here
     1333 |   CURLOPTDEPRECATED(CURLOPT_PROGRESSFUNCTION, CURLOPTTYPE_FUNCTIONPOINT, 56,
	  |   ^~~~~~~~~~~~~~~~~

This patch fixes it by replacing the CURLOPT_PROGRESSFUNCTION API (deprecated since curl 7.32.0) the modern CURLOPT_XFERINFOFUNCTION. Because librepo already needs a newer version, no additional configure-time checks or a fallback implementation are needed.

Assisted-by: Claude Code