### PR TITLE
Fix download resume within a single session

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -193,6 +193,9 @@ typedef struct {
 
     gboolean range_fail; /*!<
         Whether range request failed. */
+
+    CURLcode curl_code; /*!<
+        Result code from the last curl transfer */
 } LrTarget;
 
 typedef struct {
@@ -559,11 +562,18 @@ lr_headercb(void *ptr, size_t size, size_t nmemb, void *userdata)
                     "(converted %"G_GINT64_FORMAT"/%"G_GINT64_FORMAT" expected)",
                     __func__, content_length_str, content_length, expected);
 
-            // Compare expected size and size reported by a HTTP server
-            if (content_length > 0 && content_length != expected) {
+            // Compare expected size and size reported by a HTTP server.
+            // For resumed downloads, Content-Length
+            // is the remaining bytes, not the full file size.
+            gint64 remaining_bytes = expected;
+            if (lrtarget->resume && lrtarget->original_offset > 0) {
+                remaining_bytes = expected - lrtarget->original_offset;
+            }
+
+            if (content_length > 0 && content_length != remaining_bytes) {
                 g_debug("%s: Size doesn't match (%"G_GINT64_FORMAT
                         " != %"G_GINT64_FORMAT")",
-                        __func__, content_length, expected);
+                        __func__, content_length, remaining_bytes);
                 lrtarget->headercb_state = LR_HCS_INTERRUPTED;
                 lrtarget->headercb_interrupt_reason = g_strdup_printf(
                     "Inconsistent server data, reported file Content-Length: %"G_GINT64_FORMAT
@@ -1560,19 +1570,6 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     int fd = fileno(target->f);
 
-    // Allow resume only for files that were originally being
-    // downloaded by librepo
-    if (target->resume && !has_librepo_xattr(fd)) {
-        target->resume = FALSE;
-        g_debug("%s: Resume ignored, existing file was not originally "
-                "being downloaded by Librepo", __func__);
-        if (ftruncate(fd, 0) == -1) {
-            g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
-                        "ftruncate() failed: %s", g_strerror(errno));
-            goto fail;
-        }
-    }
-
     if (target->resume && target->resume_count >= LR_DOWNLOADER_MAXIMAL_RESUME_COUNT) {
         target->resume = FALSE;
         g_debug("%s: Download resume ignored, maximal number of attempts (%d)"
@@ -1581,8 +1578,6 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
 
     // Resume - set offset to resume incomplete download
     if (target->resume) {
-        target->resume_count++;
-
         if (target->original_offset == -1) {
             // Determine offset
             fseek(target->f, 0L, SEEK_END);
@@ -1593,15 +1588,41 @@ prepare_next_transfer(LrDownload *dd, gboolean *candidatefound, GError **err)
                 determined_offset = 0;
             }
             target->original_offset = determined_offset;
+        } else if (target->original_offset > 0) {
+            // Seek the file to the resume offset so that received
+            // data is written at the correct position.
+            fseek(target->f, target->original_offset, SEEK_SET);
         }
 
-        gint64 used_offset = target->original_offset;
-        g_debug("%s: Used offset for download resume: %"G_GINT64_FORMAT,
-                __func__, used_offset);
+        // Starting from offset 0 is a fresh download, not a resume.
+        if (target->original_offset > 0) {
+            target->resume_count++;
+        }
 
-        c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
-                                (curl_off_t) used_offset);
-        assert(c_rc == CURLE_OK);
+        // Allow resume only for files that were originally being
+        // downloaded by librepo. Check after offset determination so
+        // that new/empty files (offset 0) are not affected — there is
+        // nothing to validate and the xattr has not been set yet.
+        if (target->original_offset > 0 && !has_librepo_xattr(fd)) {
+            target->resume = FALSE;
+            g_debug("%s: Resume ignored, existing file was not originally "
+                    "being downloaded by Librepo", __func__);
+            if (ftruncate(fd, 0) == -1) {
+                g_set_error(err, LR_DOWNLOADER_ERROR, LRE_IO,
+                            "ftruncate() failed: %s", g_strerror(errno));
+                goto fail;
+            }
+            target->original_offset = 0;
+        } else {
+            gint64 used_offset = target->original_offset;
+
+            g_debug("%s: Used offset for download resume: %"G_GINT64_FORMAT,
+                    __func__, used_offset);
+
+            c_rc = curl_easy_setopt(h, CURLOPT_RESUME_FROM_LARGE,
+                                    (curl_off_t) used_offset);
+            assert(c_rc == CURLE_OK);
+        }
     }
 
     // Add librepo extended attribute to the file
@@ -1824,6 +1845,8 @@ check_finished_transfer_status(CURLMsg *msg,
     assert(!err || *err == NULL);
 
     *fatal_error = FALSE;
+
+    target->curl_code = msg->data.result;
 
     curl_easy_getinfo(msg->easy_handle,
                       CURLINFO_EFFECTIVE_URL,
@@ -2449,17 +2472,34 @@ transfer_error:
                   }
                   target->state = LR_DS_WAITING;
                   retry = TRUE;
-                  g_error_free(transfer_err);  // Ignore the error
 
-                  // Truncate file - remove downloaded garbage (error html page etc.)
                   #ifdef WITH_ZCHUNK
                   if (!target->target->is_zchunk || target->zck_state == LR_ZCK_DL_HEADER) {
                   #endif
-                    if (!truncate_transfer_file(target, err))
-                        return FALSE;
+                    if (target->target->resume
+                        && transfer_err->code == LRE_CURL
+                        && target->headercb_state != LR_HCS_INTERRUPTED
+                        && target->curl_code != CURLE_RANGE_ERROR)
+                    {
+                        // Connection error (timeout, recv error, etc.) with
+                        // potentially valid partial data. Keep the data and
+                        // let prepare_next_transfer() detect the offset from
+                        // the current file size.
+                        target->original_offset = -1;
+                    } else {
+                        // Server error (bad HTTP status), checksum mismatch,
+                        // header callback interrupt, or range error — data is
+                        // garbage. Truncate the file back to original_offset.
+                        if (!truncate_transfer_file(target, err)) {
+                            g_error_free(transfer_err);
+                            return FALSE;
+                        }
+                    }
                   #ifdef WITH_ZCHUNK
                   }
                   #endif
+
+                  g_error_free(transfer_err);  // Ignore the error
                 }
             }
 

--- a/tests/python/tests/servermock/yum_mock/config.py
+++ b/tests/python/tests/servermock/yum_mock/config.py
@@ -5,6 +5,7 @@ BADURL = "yum/badurl/"
 BADGPG = "yum/badgpg/"
 AUTHBASIC = "yum/auth_basic/"
 PARTIAL = "yum/partial/"
+RANGE_ONLY = "yum/range_only/"
 
 AUTH_USER = "admin"
 AUTH_PASS = "secret"

--- a/tests/python/tests/servermock/yum_mock/yum_mock.py
+++ b/tests/python/tests/servermock/yum_mock/yum_mock.py
@@ -120,6 +120,57 @@ def yum_mock_handler(port):
                 path += ".bad"
             self.serve_file(path)
 
+        def serve_partial(self):
+            """Serve only the first half of a file then close connection,
+            simulating a connection drop mid-download.
+            URL format: /yum/partial/<path>"""
+            path = self.parse_path('/yum/partial/')
+            if "static/" not in path:
+                return self.return_bad_request()
+            path = path[path.find("static/"):]
+            try:
+                with open(file_path(path), 'rb') as f:
+                    data = f.read()
+            except IOError:
+                return self.return_not_found()
+            half = len(data) // 2
+            # Send full Content-Length but only write first half
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/octet-stream')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data[:half])
+            self.wfile.flush()
+
+        def serve_range_only(self):
+            """Serve file only if a Range header is present (206),
+            otherwise return 404. This proves the client is resuming.
+            URL format: /yum/range_only/<path>"""
+            path = self.parse_path('/yum/range_only/')
+            if "static/" not in path:
+                return self.return_bad_request()
+            path = path[path.find("static/"):]
+            try:
+                with open(file_path(path), 'rb') as f:
+                    data = f.read()
+            except IOError:
+                return self.return_not_found()
+            range_header = self.headers.get('Range')
+            if not range_header or not range_header.startswith('bytes='):
+                return self.return_not_found()
+            range_spec = range_header[6:]
+            start_str = range_spec.split('-')[0]
+            start = int(start_str) if start_str else 0
+            remaining = data[start:]
+            self.send_response(206)
+            self.send_header('Content-Type', 'application/octet-stream')
+            end_byte = len(data) - 1
+            self.send_header('Content-Range',
+                             'bytes %d-%d/%d' % (start, end_byte, len(data)))
+            self.send_header('Content-Length', str(len(remaining)))
+            self.end_headers()
+            self.wfile.write(remaining)
+
         def serve_auth_basic(self):
             """Page secured with basic HTTP auth; User: admin Password: secret"""
             if not self.check_auth():
@@ -144,6 +195,10 @@ def yum_mock_handler(port):
                 return self.serve_badurl()
             if self.path.startswith('/yum/badgpg/'):
                 return self.serve_badgpg()
+            if self.path.startswith('/yum/partial/'):
+                return self.serve_partial()
+            if self.path.startswith('/yum/range_only/'):
+                return self.serve_range_only()
             if self.path.startswith('/yum/auth_basic/'):
                 return self.serve_auth_basic()
             return self.serve_static()

--- a/tests/python/tests/test_yum_package_downloading.py
+++ b/tests/python/tests/test_yum_package_downloading.py
@@ -782,6 +782,38 @@ class TestCaseYumPackagesDownloading(TestCaseWithServer):
         self.assertTrue(os.path.isfile(pkg.local_path))
         self.assertEqual(open(pkg.local_path, "rb").read(), CONTENT.encode('utf-8'))
 
+    def test_download_packages_resume_on_mirror_switch(self):
+        h = librepo.Handle()
+
+        # First mirror serves only half of the file then drops connection.
+        # Second mirror only serves Range requests (returns 404 otherwise)
+        # If the second mirror succeeds it proves librepo did not ask for
+        # fresh new download but resume worked.
+        url_partial = "%s%sstatic/01/" % (self.MOCKURL, config.PARTIAL)
+        url_range_only = "%s%sstatic/01/" % (self.MOCKURL, config.RANGE_ONLY)
+        h.urls = [url_partial, url_range_only]
+        h.repotype = librepo.LR_YUMREPO
+        h.maxparalleldownloads = 1
+
+        pkgs = []
+        pkgs.append(librepo.PackageTarget(config.PACKAGE_01_01,
+                                          handle=h,
+                                          dest=self.tmpdir,
+                                          resume=True,
+                                          checksum_type=librepo.SHA256,
+                                          checksum=config.PACKAGE_01_01_SHA256))
+
+        librepo.download_packages(pkgs, failfast=True)
+
+        pkg = pkgs[0]
+        self.assertTrue(pkg.err is None)
+        self.assertTrue(os.path.isfile(pkg.local_path))
+
+        with open(pkg.local_path, 'rb') as f:
+            data = f.read()
+        sha256 = hashlib.sha256(data).hexdigest()
+        self.assertEqual(sha256, config.PACKAGE_01_01_SHA256)
+
     def test_download_packages_mirror_penalization_01(self):
 
         # This test is useful for mirror penalization testing


### PR DESCRIPTION
Download resume was effectively broken - when a transfer failed and was retried on another mirror, the partial data was always discarded and the download restarted from scratch. Several issues contributed to this:

1. Header callback breaks resumed transfers: For HTTP 206 Partial Content responses, Content-Length contains the remaining bytes, not the full file size.

2. Retry always discards partial data: On transfer failure, truncate_transfer_file() unconditionally truncated back to original_offset (0 for new files), and original_offset was never updated. Now, for connection errors (timeout, recv error, etc.) where partial data is likely valid, the file is kept and original_offset is updated to the current file size so the next attempt resumes from where it left off. Server errors (bad HTTP status), checksum failures, and header callback interrupts still truncate as before.

3. File position not set on resume: When resuming a download, the file pointer was left at position 0 after fdopen. Data received from the server (starting at the resume offset) was written at position 0, corrupting the file.

4. resume flag not re-enabled on retry: The xattr check in prepare_next_transfer permanently disabled the resume flag for new files (no xattr on first open). On retry after a connection error, resume was not re-enabled, preventing the use of CURLOPT_RESUME_FROM_LARGE.

5. resume_count incremented on non-resume attempts: The resume attempt counter was incremented on every prepare_next_transfer call, even for fresh downloads (offset 0). This meant resume was disabled before any actual resume could happen.

Also a test is added for resuming the download after a mirror switch.

Related: https://github.com/rpm-software-management/librepo/issues/293