### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,6 +2,8 @@
 # https://packit.dev/docs/configuration
 
 specfile_path: librepo.spec
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
 
 # Build the package with the current specfile version (otherwise it uses last git tag).
 # This is needed because other packages can depend on the new version.


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.
For https://github.com/rpm-software-management/ci-dnf-stack/issues/1843

Example build: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10266049/