### PR TITLE
Close zchunk seed fd in find_local_zck_header

### DIFF
--- a/librepo/downloader.c
+++ b/librepo/downloader.c
@@ -1103,7 +1103,8 @@ find_local_zck_header(LrTarget *target, GError **err)
                    ftruncate(fd, lseek(chk_fd, 0, SEEK_END)) >= 0 &&
                    lseek(fd, 0, SEEK_SET) == 0 &&
                    (zck = lr_zck_init_read(target->target, (char *)file->data,
-                                           chk_fd, &tmp_err))) {
+                                           fd, &tmp_err))) {
+                    close(chk_fd);
                     found = TRUE;
                     break;
                 } else {


### PR DESCRIPTION
`find_local_zck_header()` opens the old cached .zck file as a seed for delta downloads but never closes the fd when a match is found (the break skips the close call). The fd stays open until `lr_free(target)`, which happens after the end callback.

dnf5 registers an end callback that removes the old repodata/ directory and moves freshly downloaded metadata into place. On NFS, unlinking a file with an open fd does not remove the directory entry but creates a .nfs* silly-rename file instead. The final rmdir then fails with ENOTEMPTY, causing "Failed to download metadata" errors.

The seed file content is already fully copied to the target fd via `lr_copy_content()` before `lr_zck_init_read()` is called. Pass the target fd instead of the seed fd to `lr_zck_init_read()` so that the seed fd can be closed immediately.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2459175