### PR TITLE
Fix metadata file descriptor leaks

### DIFF
--- a/librepo/yum.c
+++ b/librepo/yum.c
@@ -669,22 +669,9 @@ gboolean
 prepare_repo_download_std_target(LrHandle *handle,
                                  LrYumRepoMdRecord *record,
                                  char **path,
-                                 int *fd,
-                                 GSList **checksums,
-                                 GSList **targets,
-                                 GError **err)
+                                 GSList **checksums)
 {
     *path = lr_pathconcat(handle->destdir, record->location_href, NULL);
-    *fd = open(*path, O_CREAT|O_TRUNC|O_RDWR, 0666);
-    if (*fd < 0) {
-        g_debug("%s: Cannot create/open %s (%s)",
-                __func__, *path, g_strerror(errno));
-        g_set_error(err, LR_YUM_ERROR, LRE_IO,
-                    "Cannot create/open %s: %s", *path, g_strerror(errno));
-        g_free(*path);
-        g_slist_free_full(*targets, (GDestroyNotify) lr_downloadtarget_free);
-        return FALSE;
-    }
 
     if (handle->checks & LR_CHECK_CHECKSUM) {
         // Select proper checksum type only if checksum check is enabled
@@ -702,22 +689,9 @@ gboolean
 prepare_repo_download_zck_target(LrHandle *handle,
                                  LrYumRepoMdRecord *record,
                                  char **path,
-                                 int *fd,
-                                 GSList **checksums,
-                                 GSList **targets,
-                                 GError **err)
+                                 GSList **checksums)
 {
     *path = lr_pathconcat(handle->destdir, record->location_href, NULL);
-    *fd = open(*path, O_CREAT|O_RDWR, 0666);
-    if (*fd < 0) {
-        g_debug("%s: Cannot create/open %s (%s)",
-                __func__, *path, g_strerror(errno));
-        g_set_error(err, LR_YUM_ERROR, LRE_IO,
-                    "Cannot create/open %s: %s", *path, g_strerror(errno));
-        g_free(*path);
-        g_slist_free_full(*targets, (GDestroyNotify) lr_downloadtarget_free);
-        return FALSE;
-    }
 
     if (handle->checks & LR_CHECK_CHECKSUM) {
         // Select proper checksum type only if checksum check is enabled
@@ -756,7 +730,6 @@ prepare_repo_download_targets(LrHandle *handle,
     }
 
     for (GSList *elem = repomd->records; elem; elem = g_slist_next(elem)) {
-        int fd;
         char *path;
         LrDownloadTarget *target;
         LrYumRepoMdRecord *record = elem->data;
@@ -800,13 +773,13 @@ prepare_repo_download_targets(LrHandle *handle,
         GSList *checksums = NULL;
         if (is_zchunk) {
             #ifdef WITH_ZCHUNK
-            if(!prepare_repo_download_zck_target(handle, record, &path, &fd,
-                                                 &checksums, targets, err))
+            if(!prepare_repo_download_zck_target(handle, record, &path,
+                                                 &checksums))
                 return FALSE;
             #endif /* WITH_ZCHUNK */
         } else {
-            if(!prepare_repo_download_std_target(handle, record, &path, &fd,
-                                                 &checksums, targets, err))
+            if(!prepare_repo_download_std_target(handle, record, &path,
+                                                 &checksums))
                 return FALSE;
         }
 
@@ -822,8 +795,8 @@ prepare_repo_download_targets(LrHandle *handle,
         target = lr_downloadtarget_new(handle,
                                        location_href,
                                        record->location_base,
-                                       fd,
-                                       NULL,
+                                       -1,
+                                       path,
                                        checksums,
                                        0,
                                        0,

--- a/tests/python/tests/test_yum_repo_downloading.py
+++ b/tests/python/tests/test_yum_repo_downloading.py
@@ -770,7 +770,7 @@ class TestCaseYumRepoDownloading(TestCaseWithServer):
 
         self.assertTrue(yum_repo)
         self.assertTrue(yum_repomd)
-        self.assertTrue(os.path.getsize(yum_repo["primary"]) == 0)
+        self.assertFalse(os.path.exists(yum_repo["primary"]))
 
     def test_download_repo_01_with_missing_unwanted_file(self):
         h = librepo.Handle()


### PR DESCRIPTION
The opened `fd`'s were never closed.

We don't have to preopen `fd` for `LrMetadataTarget` rather pass it by `fn`. It is later correctly opened with the same flags (taking zchunk into account) and closed.

Discovered in dnf5 by running: `valgrind --track-fds=yes ./build/test/libdnf5/run_tests`
(There is still one fd leak but its a test implementation problem that is unrelated.)