### PR TITLE
Unify error messages for GPG errors across backends

### DIFF
--- a/librepo/gpg_gpgme.c
+++ b/librepo/gpg_gpgme.c
@@ -286,8 +286,13 @@ lr_gpg_check_signature_fd(int signature_fd,
     gboolean found_valid_signature = FALSE;
     gboolean found_expired_key = FALSE;
     gboolean found_expired_sig = FALSE;
+    gboolean found_missing_key = FALSE;
     for (; sig; sig = sig->next) {
-        // Check if this signature is from an expired key or is itself expired
+        if (sig->summary & GPGME_SIGSUM_KEY_MISSING ||
+            gpg_err_code(sig->status) == GPG_ERR_NO_PUBKEY) {
+            found_missing_key = TRUE;
+            continue;
+        }
         if (sig->summary & GPGME_SIGSUM_KEY_EXPIRED) {
             g_debug("%s: Skipping signature with expired key", __func__);
             found_expired_key = TRUE;
@@ -315,15 +320,18 @@ lr_gpg_check_signature_fd(int signature_fd,
     }
 
     // No valid signature found - report appropriate error
-    if (found_expired_key) {
-        g_debug("%s: GPG signature verification failed - key has expired", __func__);
-        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "GPG signature verification failed - key has expired");
+    if (found_missing_key) {
+        g_debug("%s: " LR_GPG_ERR_SIGNING_KEY_NOT_FOUND, __func__);
+        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_SIGNING_KEY_NOT_FOUND);
+    } else if (found_expired_key) {
+        g_debug("%s: " LR_GPG_ERR_BAD_SIGNATURE ": key has expired", __func__);
+        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_BAD_SIGNATURE ": key has expired");
     } else if (found_expired_sig) {
-        g_debug("%s: GPG signature verification failed - signature has expired", __func__);
-        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "GPG signature verification failed - signature has expired");
+        g_debug("%s: " LR_GPG_ERR_BAD_SIGNATURE ": signature has expired", __func__);
+        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_BAD_SIGNATURE ": signature has expired");
     } else {
-        g_debug("%s: Bad GPG signature", __func__);
-        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "Bad GPG signature");
+        g_debug("%s: " LR_GPG_ERR_BAD_SIGNATURE, __func__);
+        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_BAD_SIGNATURE);
     }
     return FALSE;
 }

--- a/librepo/gpg_internal.h
+++ b/librepo/gpg_internal.h
@@ -23,6 +23,9 @@
 
 #include <glib.h>
 
+#define LR_GPG_ERR_SIGNING_KEY_NOT_FOUND  "Signing key not found"
+#define LR_GPG_ERR_BAD_SIGNATURE          "Bad PGP signature"
+
 struct tLrGpgSubkey {
     gboolean has_next;   // FALSE if this is the last subkey in the list
     char *id;            // subkey id

--- a/librepo/gpg_rpm.c
+++ b/librepo/gpg_rpm.c
@@ -599,18 +599,18 @@ check_signature(const gchar * sig_buf, ssize_t sig_buf_len, const gchar * data, 
         ret = ret_verify == RPMRC_OK || ret_verify == RPMRC_NOTTRUSTED;
         if (!ret) {
             if (message == NULL) {
-                g_debug("%s: Bad PGP signature", __func__);
-                g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "Bad PGP signature");
+                g_debug("%s: " LR_GPG_ERR_BAD_SIGNATURE, __func__);
+                g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_BAD_SIGNATURE);
             } else {
-                g_debug("%s: Bad PGP signature: %s", __func__, message);
-                g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "Bad PGP signature: %s", message);
+                g_debug("%s: " LR_GPG_ERR_BAD_SIGNATURE ": %s", __func__, message);
+                g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_BAD_SIGNATURE ": %s", message);
             }
         }
         if (message != NULL)
             free(message);
     } else {
-        g_debug("%s: Signing key not found", __func__);
-        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, "Signing key not found");
+        g_debug("%s: " LR_GPG_ERR_SIGNING_KEY_NOT_FOUND, __func__);
+        g_set_error(err, LR_GPG_ERROR, LRE_BADGPG, LR_GPG_ERR_SIGNING_KEY_NOT_FOUND);
     }
 
     pgpDigParamsFree(signature_dig_params);

--- a/tests/test_gpg.c
+++ b/tests/test_gpg.c
@@ -291,6 +291,42 @@ START_TEST(test_gpg_check_import_padded)
 END_TEST
 
 
+START_TEST(test_gpg_missing_key_error_message)
+{
+    // When verifying a signature without the signing key in the keyring,
+    // both backends must report "Signing key not found" so that dnf5's
+    // retry logic can trigger GPG key import.
+    gboolean ret;
+    char *data_path, *signature_path;
+    char *tmp_home_path;
+    GError *tmp_err = NULL;
+
+    tmp_home_path = lr_gettmpdir();
+    data_path = lr_pathconcat(test_globals.testdata_dir,
+                             "repo_yum_01/repodata/repomd.xml", NULL);
+    signature_path = lr_pathconcat(test_globals.testdata_dir,
+                             "repo_yum_01/repodata/repomd.xml.asc", NULL);
+
+    // Do NOT import any key — the keyring is empty.
+    ret = lr_gpg_check_signature(signature_path,
+                                 data_path,
+                                 tmp_home_path,
+                                 &tmp_err);
+    ck_assert(!ret);
+    ck_assert_ptr_nonnull(tmp_err);
+    ck_assert_msg(g_str_has_suffix(tmp_err->message, "Signing key not found"),
+                  "Expected error ending with 'Signing key not found', got: %s",
+                  tmp_err->message);
+    g_clear_error(&tmp_err);
+
+    lr_remove_dir(tmp_home_path);
+    lr_free(data_path);
+    lr_free(signature_path);
+    g_free(tmp_home_path);
+}
+END_TEST
+
+
 START_TEST(test_gpgme_expired_signature)
 {
     // This test verifies that expired GPG signatures are properly rejected
@@ -379,6 +415,7 @@ gpg_suite(void)
     tcase_add_test(tc, test_gpg_check_armored_key_import_test_export);
     tcase_add_test(tc, test_gpg_check_binary_key_import_test_export);
     tcase_add_test(tc, test_gpg_check_import_padded);
+    tcase_add_test(tc, test_gpg_missing_key_error_message);
     tcase_add_test(tc, test_gpgme_expired_signature);
     suite_add_tcase(s, tc);
     return s;


### PR DESCRIPTION
When `repo_gpgcheck` is enabled, dnf5 first attempts to verify the repository metadata signature and, if the error message indicates the signing key is not in the keyring (`Signing key not found`), it downloads and imports the key from gpgkey URLs and retries.

The gpgme backend did not distinguish between a missing key and a genuinely bad signature, and reported the generic "Bad GPG signature" for both cases. This prevented dnf5's key import retry from triggering, causing repo_gpgcheck=1 to always fail on the first run on distros that build librepo with `USE_GPGME=ON` (Arch Linux, openSUSE).

Also a test is added to verify, that a missing key is correctly reported for backend used to compile librepo.

Resolves: https://github.com/rpm-software-management/librepo/issues/376

