### PR TITLE
Load PKCS#11 Provider and Use PROV Certificate Type on OpenSSL 4.x

### DIFF
--- a/librepo/handle.c
+++ b/librepo/handle.c
@@ -58,6 +58,18 @@
   #define LR_PKCS11_TYPE "ENG"
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+#include <openssl/provider.h>
+
+static CURLcode
+lr_ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *userptr)
+{
+    (void)curl; (void)userptr;
+    OSSL_PROVIDER_load(ssl_ctx, "pkcs11");
+    return CURLE_OK;
+}
+#endif
+
 CURL *
 lr_get_curl_handle()
 {


### PR DESCRIPTION
OpenSSL 4.x removes support for the legacy ENGINE framework, but librepo currently continues to configure PKCS#11 certificates and keys using the "ENG" type.

This PR:

Switches PKCS#11 certificate and key types from "ENG" to "PROV" on OpenSSL 4.x.
Explicitly loads the PKCS#11 provider within curl's SSL context.

Testing on Fedora 45 showed that changing the type alone is insufficient because the PKCS#11 provider is not available during TLS certificate processing. Loading the provider fixes the issue and enables successful TPM2-backed PKCS#11 certificate authentication.